### PR TITLE
Use std::deque instead of self-crafted linked list

### DIFF
--- a/c7a/data/binary_buffer_reader.hpp
+++ b/c7a/data/binary_buffer_reader.hpp
@@ -68,6 +68,10 @@ public:
         return (cursor_ == size_);
     }
 
+    size_t Size() const {
+        return size_;
+    }
+
     //! \}
 
     //! \name Cursor Movement and Checks


### PR DESCRIPTION
CA-125 #comment BufferChain uses deque now.

You can delete the branch afterwards.
