### PR TITLE
use template switch for c7a::common::stats

### DIFF
--- a/c7a/api/context.hpp
+++ b/c7a/api/context.hpp
@@ -82,7 +82,7 @@ public:
         return job_manager_.net_manager().MyRank();
     }
 
-    common::Stats & stats() {
+    common::Stats<ENABLE_STATS> & stats() {
         return stats_;
     }
 
@@ -100,7 +100,7 @@ public:
 
 private:
     core::JobManager& job_manager_;
-    common::Stats stats_;
+    common::Stats<ENABLE_STATS> stats_;
     api::StatsGraph stats_graph_;
 
     //! number of this worker context, 0..p-1, within this compute node.

--- a/c7a/common/stats.hpp
+++ b/c7a/common/stats.hpp
@@ -41,9 +41,12 @@ namespace common {
 //!
 //! All Counters and such are held locally until the destructor is called.
 //! Depending on the configuration all Counters and such will be printed to sLOG
-//!
-//! Returns null pointers if built with ENABLE_STATS=off
+template <bool Active>
 class Stats
+{ };
+
+template <>
+class Stats<true>
 {
 public:
     using NamedTimedcounter = std::pair<std::string, TimedCounter>;
@@ -53,7 +56,6 @@ public:
     Stats(Stats&&) = delete;
     Stats& operator = (const Stats&) = delete;
 
-#if ENABLE_STATS
     Stats() :
         program_start_(std::chrono::high_resolution_clock::now()) { }
 
@@ -159,19 +161,32 @@ private:
     inline long Relative(const TimeStamp& time_point) {
         return std::chrono::duration_cast<std::chrono::milliseconds>(time_point - program_start_).count();
     }
-#else       //ENABLE_STATS
-    Stats() = default;
+};
 
-    TimedCounterPtr CreateTimedCounter(const std::string& /*group*/, const std::string& /*label*/) {
+template <>
+class Stats<false>
+{
+public:
+    Stats() = default;
+    Stats(const Stats& rhs) = delete;
+    Stats(Stats&&) = delete;
+    Stats& operator = (const Stats&) = delete;
+
+    TimedCounterPtr CreateTimedCounter(const std::string& /* group */, const std::string& /*label*/) {
         return TimedCounterPtr();
     }
-    TimerPtr CreateTimer(const std::string& /*group*/, const std::string& /*label*/, bool /*auto_start*/ = false) {
+
+    TimerPtr CreateTimer(const std::string& /*group*/, const std::string& /*label*/) {
         return TimerPtr();
     }
-    void AddReport(const std::string& /*group*/, const std::string& /*label*/, const std::string& /*content*/) {
-        //noop
+
+    TimerPtr CreateTimer(const std::string& /*group*/, const std::string& /*label*/, bool /*auto_start */) {
+        return TimerPtr();
     }
-#endif      //ENABLE_STATS
+
+    void AddReport(const std::string& /*group*/, const std::string& /*label*/, const std::string& /*content*/) {
+        //do nothing
+    }
 };
 
 } // namespace common

--- a/tests/common/stats_timer_test.cpp
+++ b/tests/common/stats_timer_test.cpp
@@ -9,6 +9,7 @@
  ******************************************************************************/
 
 #include <c7a/common/stats_timer.hpp>
+#include <c7a/common/stats.hpp> //for forced instantiation below
 #include <gtest/gtest.h>
 
 #include <thread>
@@ -47,6 +48,8 @@ namespace common {
 // forced instantiations
 template class StatsTimer<true>;
 template class StatsTimer<false>;
+template class Stats<true>;
+template class Stats<false>;
 
 } // namespace common
 } // namespace c7a


### PR DESCRIPTION
CA-188 #comment did not completely remove compile flat, but use template swith internally. There is a forced instatiation in a test case.
