### PR TITLE
Added a wrapper for File::Reader that supports peeking.

### DIFF
--- a/c7a/data/buffered_block_reader.hpp
+++ b/c7a/data/buffered_block_reader.hpp
@@ -23,11 +23,11 @@ namespace data {
 /*!
  * Simple block reader that allows reading the first value without advancing. 
  */
-template <typename ItemType>
+template <typename ItemType, typename BlockSource>
 class BufferedBlockReader
 {
 private:
-    File::Reader &reader_;
+    BlockReader<BlockSource> reader_;
     ItemType current_;
     bool hasCurrent_;
 public:
@@ -51,17 +51,15 @@ public:
      * Advances this reader to the next value. 
      */
     void Next() {
-        assert(HasValue());
-
         hasCurrent_ = reader_.HasNext();
         if(hasCurrent_)
-            current_ = reader_.Next<ItemType>();
+            current_ = reader_.template Next<ItemType>();
     }
 
     /*!
      * Creates a new instance of this class, based on the given file reader.
      */
-    BufferedBlockReader(File::Reader &reader) : reader_(reader) {
+    BufferedBlockReader(BlockReader<BlockSource> reader) : reader_(reader) {
         Next();    
     }
 };

--- a/c7a/data/file.hpp
+++ b/c7a/data/file.hpp
@@ -15,6 +15,7 @@
 #include <c7a/common/logger.hpp>
 #include <c7a/data/block.hpp>
 #include <c7a/data/block_reader.hpp>
+#include <c7a/data/buffered_block_reader.hpp>
 #include <c7a/data/block_sink.hpp>
 #include <c7a/data/block_writer.hpp>
 #include <c7a/data/dyn_block_reader.hpp>
@@ -110,6 +111,10 @@ public:
 
     //! Get BlockReader for beginning of File
     Reader GetReader() const;
+
+    //! Get BufferedBlockReader for beginning of File
+    template <typename ValueType>
+    BufferedBlockReader<ValueType, FileBlockSource> GetBufferedReader() const;
 
     //! return polymorphic BlockReader variant for beginning of File
     DynReader GetDynReader() const;
@@ -220,6 +225,11 @@ protected:
 //! Get BlockReader for beginning of File
 inline typename File::Reader File::GetReader() const {
     return Reader(FileBlockSource(*this, 0, 0));
+}
+
+template <typename ValueType>
+inline BufferedBlockReader<ValueType, FileBlockSource> File::GetBufferedReader() const {
+    return BufferedBlockReader<ValueType, FileBlockSource>(GetReader());
 }
 
 inline

--- a/tests/data/file_test.cpp
+++ b/tests/data/file_test.cpp
@@ -184,8 +184,7 @@ TEST(File, ReadFileWIthBufferedReader) {
     }    
     fw.Close();
 
-    data::File::Reader fr = file.GetReader();
-    data::BufferedBlockReader<size_t> br(fr);
+    auto br = file.GetBufferedReader<size_t>();
 
     for(size_t i = 0 ; i < size; i++) {
         ASSERT_TRUE(br.HasValue());


### PR DESCRIPTION
Implementation is straight-forward. I'm still unsure if I should pass a BlockReader<T> instead of a File::Reader. However, I'm unsure about interfering the template parameter T automatically... 
