### PR TITLE
Don't move temporary objects returned by value

### DIFF
--- a/thrill/api/allgather.hpp
+++ b/thrill/api/allgather.hpp
@@ -100,7 +100,7 @@ std::vector<ValueType> DIARef<ValueType, Stack>::AllGather()  const {
 
     core::StageBuilder().RunScope(shared_node.get());
 
-    return std::move(output);
+    return output;
 }
 
 template <typename ValueType, typename Stack>

--- a/thrill/api/context.cpp
+++ b/thrill/api/context.cpp
@@ -35,7 +35,7 @@ HostContext::ConstructLocalMock(size_t host_count, size_t workers_per_host) {
     std::array<std::vector<net::Group>, kGroupCount> group;
 
     for (size_t g = 0; g < kGroupCount; ++g) {
-        group[g] = std::move(net::Group::ConstructLocalMesh(host_count));
+        group[g] = net::Group::ConstructLocalMesh(host_count);
     }
 
     // construct host context

--- a/thrill/api/context.hpp
+++ b/thrill/api/context.hpp
@@ -222,7 +222,7 @@ public:
     //! the context and must be called on all Workers to ensure correct
     //! communication coordination.
     data::ChannelPtr GetNewChannel() {
-        return std::move(multiplexer_.GetNewChannel(local_worker_id_));
+        return multiplexer_.GetNewChannel(local_worker_id_);
     }
 
     //! the block manager keeps all data blocks moving through the system.

--- a/thrill/common/future_queue.hpp
+++ b/thrill/common/future_queue.hpp
@@ -109,7 +109,7 @@ public:
 
         T elem = std::move(elements_.front());
         elements_.pop_front();
-        return std::move(elem);
+        return elem;
     }
 };
 

--- a/thrill/data/multiplexer.cpp
+++ b/thrill/data/multiplexer.cpp
@@ -28,11 +28,10 @@ Multiplexer::~Multiplexer() {
 }
 
 ChannelPtr Multiplexer::_GetOrCreateChannel(size_t id, size_t local_worker_id) {
-    return std::move(
-        channels_.GetOrCreate(
+    return channels_.GetOrCreate(
             id, local_worker_id,
             // initializers for Channels
-            *this, id, local_worker_id));
+            *this, id, local_worker_id);
 }
 
 /******************************************************************************/

--- a/thrill/data/multiplexer.hpp
+++ b/thrill/data/multiplexer.hpp
@@ -97,15 +97,14 @@ public:
     //! Get channel with given id, if it does not exist, create it.
     ChannelPtr GetOrCreateChannel(size_t id, size_t local_worker_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        return std::move(_GetOrCreateChannel(id, local_worker_id));
+        return _GetOrCreateChannel(id, local_worker_id);
     }
 
     //! Request next channel.
     ChannelPtr GetNewChannel(size_t local_worker_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        return std::move(
-            _GetOrCreateChannel(
-                channels_.AllocateId(local_worker_id), local_worker_id));
+        return _GetOrCreateChannel(
+                channels_.AllocateId(local_worker_id), local_worker_id);
     }
 
 private:

--- a/thrill/net/buffer_builder.hpp
+++ b/thrill/net/buffer_builder.hpp
@@ -240,7 +240,7 @@ public:
     net::Buffer ToBuffer() {
         net::Buffer b = net::Buffer::Acquire(data_, size_);
         Detach();
-        return std::move(b);
+        return b;
     }
 
     //! \}

--- a/thrill/net/buffer_ref.hpp
+++ b/thrill/net/buffer_ref.hpp
@@ -82,7 +82,7 @@ public:
         net::Buffer b = net::Buffer::Acquire(addr, size_);
         data_ = nullptr;
         size_ = 0;
-        return std::move(b);
+        return b;
     }
 
     //! Compare contents of two BufferRefs.

--- a/thrill/net/group.cpp
+++ b/thrill/net/group.cpp
@@ -43,12 +43,12 @@ std::vector<Group> Group::ConstructLocalMesh(size_t num_clients) {
             sp.first.SetNonBlocking(true);
             sp.second.SetNonBlocking(true);
 
-            group[i].connections_[j] = std::move(Connection(sp.first));
-            group[j].connections_[i] = std::move(Connection(sp.second));
+            group[i].connections_[j] = Connection(sp.first);
+            group[j].connections_[i] = Connection(sp.second);
         }
     }
 
-    return std::move(group);
+    return group;
 }
 
 void Group::ExecuteLocalMock(

--- a/thrill/net/manager.cpp
+++ b/thrill/net/manager.cpp
@@ -80,7 +80,7 @@ public:
                 throw Exception("Could not listen on socket "
                                 + lsa.ToStringHostPort(), errno);
 
-            listener_ = std::move(Connection(listen_socket));
+            listener_ = Connection(listen_socket);
         }
 
         LOG << "Client " << my_rank_ << " listening: " << endpoints[my_rank_];
@@ -305,7 +305,7 @@ protected:
         Connection& nc = groups_[group].connection(id);
         if (nc.IsValid()) nc.Close();
 
-        nc = std::move(Connection(Socket::Create()));
+        nc = Connection(Socket::Create());
         nc.set_group_id(group);
         nc.set_peer_id(id);
 
@@ -578,7 +578,7 @@ Manager::ConstructLocalMesh(size_t host_count) {
     std::array<std::vector<Group>, kGroupCount> group;
 
     for (size_t g = 0; g < kGroupCount; ++g) {
-        group[g] = std::move(Group::ConstructLocalMesh(host_count));
+        group[g] = Group::ConstructLocalMesh(host_count);
     }
 
     // construct list of uninitialized net::Manager objects.


### PR DESCRIPTION
moving such a temporary object prevents copy elision.
See Scott Meyers, "Effective Modern C++", Item 25.