### PR TITLE
Don't put braces around scalar initializers

### DIFF
--- a/benchmarks/data/data_generators.hpp
+++ b/benchmarks/data/data_generators.hpp
@@ -66,7 +66,7 @@ protected:
     ssize_t bytes_;
 
     // init randomness
-    std::default_random_engine randomness_ { std::random_device()() };
+    std::default_random_engine randomness_ { std::random_device{}() };
     std::uniform_int_distribution<size_t> uniform_dist_ { 1, 100 };
 };
 
@@ -128,7 +128,7 @@ std::vector<std::string> generate(size_t bytes, size_t min_size, size_t max_size
     size_t remaining = bytes;
 
     // init randomness
-    std::default_random_engine randomness({ std::random_device()() });
+    std::default_random_engine randomness(std::random_device{}());
     std::uniform_int_distribution<size_t> uniform_dist(min_size, max_size);
 
     while (remaining > 0) {
@@ -145,7 +145,7 @@ std::vector<Tuple> generate(size_t bytes, size_t min_size, size_t max_size) {
     size_t remaining = bytes;
 
     // init randomness
-    std::default_random_engine randomness({ std::random_device()() });
+    std::default_random_engine randomness(std::random_device{}());
     std::uniform_int_distribution<size_t> uniform_dist(min_size, max_size);
 
     while (remaining > 0) {
@@ -163,7 +163,7 @@ std::vector<Triple> generate(size_t bytes, size_t min_size, size_t max_size) {
     size_t remaining = bytes;
 
     // init randomness
-    std::default_random_engine randomness({ std::random_device()() });
+    std::default_random_engine randomness(std::random_device{}());
     std::uniform_int_distribution<size_t> uniform_dist(min_size, max_size);
 
     while (remaining > 0) {

--- a/benchmarks/hashtable/bench_bucket_hashtable.cpp
+++ b/benchmarks/hashtable/bench_bucket_hashtable.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "0123456789";
 
-    std::default_random_engine rng({ std::random_device()() });
+    std::default_random_engine rng(std::random_device{}());
     std::uniform_int_distribution<> dist(l, u);
 
     std::vector<std::string> strings;

--- a/benchmarks/hashtable/bench_probing_hashtable.cpp
+++ b/benchmarks/hashtable/bench_probing_hashtable.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "0123456789";
 
-    std::default_random_engine rng({ std::random_device()() });
+    std::default_random_engine rng(std::random_device{}());
     std::uniform_int_distribution<> dist(l, u);
 
     std::vector<std::string> strings;

--- a/tests/api/read_write_test.cpp
+++ b/tests/api/read_write_test.cpp
@@ -177,7 +177,7 @@ TEST(IO, ReadPartOfFolderCompressed) {
 TEST(IO, GenerateFromFileRandomIntegers) {
     api::RunSameThread(
         [](api::Context& ctx) {
-            std::default_random_engine generator({ std::random_device()() });
+            std::default_random_engine generator(std::random_device{}());
             std::uniform_int_distribution<int> distribution(1000, 10000);
 
             size_t generate_size = distribution(generator);

--- a/tests/api/sort_node_test.cpp
+++ b/tests/api/sort_node_test.cpp
@@ -26,7 +26,7 @@ TEST(Sort, SortKnownIntegers) {
     std::function<void(Context&)> start_func =
         [](Context& ctx) {
 
-            std::default_random_engine generator({ std::random_device()() });
+            std::default_random_engine generator(std::random_device{}());
             std::uniform_int_distribution<int> distribution(1, 10000);
 
             auto integers = Generate(
@@ -57,7 +57,7 @@ TEST(Sort, SortRandomIntegers) {
     std::function<void(Context&)> start_func =
         [](Context& ctx) {
 
-            std::default_random_engine generator({ std::random_device()() });
+            std::default_random_engine generator(std::random_device{}());
             std::uniform_int_distribution<int> distribution(1, 10000);
 
             auto integers = Generate(
@@ -88,7 +88,7 @@ TEST(Sort, SortRandomIntegersCustomCompareFunction) {
     std::function<void(Context&)> start_func =
         [](Context& ctx) {
 
-            std::default_random_engine generator({ std::random_device()() });
+            std::default_random_engine generator(std::random_device{}());
             std::uniform_int_distribution<int> distribution(1, 10000);
 
             auto integers = Generate(
@@ -125,7 +125,7 @@ TEST(Sort, SortRandomIntIntStructs) {
 
             using Pair = std::pair<int, int>;
 
-            std::default_random_engine generator({ std::random_device()() });
+            std::default_random_engine generator(std::random_device{}());
             std::uniform_int_distribution<int> distribution(1, 10);
 
             auto integers = Generate(

--- a/tests/api/sum_node_test.cpp
+++ b/tests/api/sum_node_test.cpp
@@ -23,7 +23,7 @@ using namespace thrill; // NOLINT
 
 TEST(SumNode, GenerateAndSumHaveEqualAmount1) {
 
-    std::default_random_engine generator({ std::random_device()() });
+    std::default_random_engine generator(std::random_device{}());
     std::uniform_int_distribution<int> distribution(1000, 10000);
 
     size_t generate_size = distribution(generator);

--- a/tests/net/group_test.cpp
+++ b/tests/net/group_test.cpp
@@ -147,7 +147,7 @@ static void ThreadInitializeSendReceive(Group* net) {
 static void RealGroupConstructAndCall(
     std::function<void(Group*)> thread_function) {
     // randomize base port number for test
-    std::default_random_engine generator({ std::random_device()() });
+    std::default_random_engine generator(std::random_device{}());
     std::uniform_int_distribution<int> distribution(10000, 30000);
     const size_t port_base = distribution(generator);
 

--- a/thrill/api/generate_from_file.hpp
+++ b/thrill/api/generate_from_file.hpp
@@ -97,7 +97,7 @@ public:
             local_elements = elements_per_worker;
         }
 
-        std::default_random_engine generator({ std::random_device()() });
+        std::default_random_engine generator(std::random_device{}());
         std::uniform_int_distribution<int> distribution(0, elements_.size() - 1);
 
         for (size_t i = 0; i < local_elements; i++) {

--- a/thrill/api/sort.hpp
+++ b/thrill/api/sort.hpp
@@ -300,7 +300,7 @@ private:
 
         LOG << prefix_elem << " elements, out of " << total_elem;
 
-        std::default_random_engine generator({ std::random_device()() });
+        std::default_random_engine generator(std::random_device{}());
         std::uniform_int_distribution<int> distribution(0, data_.size() - 1);
 
         // Send samples to worker 0


### PR DESCRIPTION
This is a way of making `std::random_device()()` compile, but it's wrong. Use `std::random_device{}()` instead and it's not needed.