### PR TITLE
Include Collective Communication

### DIFF
--- a/tests/api/graph_test.cpp
+++ b/tests/api/graph_test.cpp
@@ -8,6 +8,7 @@
  ******************************************************************************/
 
 #include <thrill/api/allgather.hpp>
+#include <thrill/api/context.hpp>
 #include <thrill/api/cache.hpp>
 #include <thrill/api/collapse.hpp>
 #include <thrill/api/dia.hpp>

--- a/tests/api/graph_test.cpp
+++ b/tests/api/graph_test.cpp
@@ -8,9 +8,9 @@
  ******************************************************************************/
 
 #include <thrill/api/allgather.hpp>
-#include <thrill/api/context.hpp>
 #include <thrill/api/cache.hpp>
 #include <thrill/api/collapse.hpp>
+#include <thrill/api/context.hpp>
 #include <thrill/api/dia.hpp>
 #include <thrill/api/generate.hpp>
 #include <thrill/api/generate_from_file.hpp>
@@ -18,7 +18,6 @@
 #include <thrill/api/read_lines.hpp>
 #include <thrill/api/size.hpp>
 #include <thrill/api/stats_graph.hpp>
-#include <thrill/api/write_lines_many.hpp>
 #include <thrill/api/zip.hpp>
 #include <thrill/common/logger.hpp>
 

--- a/tests/net/flow_control_test_base.hpp
+++ b/tests/net/flow_control_test_base.hpp
@@ -145,13 +145,20 @@ static void TestMultiThreadPrefixSum(net::Group* net) {
         net, count, [=](net::FlowControlChannel& channel, size_t id) {
             size_t myRank = net->my_host_rank() * count + id;
 
-            size_t res = channel.PrefixSum(myRank);
-            size_t expected = 0;
+            size_t resInclusive = channel.PrefixSum(myRank, std::plus<size_t>, true);
+            size_t resExclusive = channel.PrefixSum(myRank, std::plus<size_t>, false);
+            size_t expectedInclusive = 0;
+            size_t expectedInclusive = 0;
+
             for (size_t i = 0; i <= net->my_host_rank() * count + id; i++) {
-                expected += i;
+                expectedInclusive += i;
+            }
+            for (size_t i = 0; i < net->my_host_rank() * count + id; i++) {
+                expectedExclusive += i;
             }
 
-            ASSERT_EQ(res, expected);
+            ASSERT_EQ(resInclusive, expectedInclusive);
+            ASSERT_EQ(resExclusive, expectedExclusive);
         });
 }
 

--- a/tests/net/flow_control_test_base.hpp
+++ b/tests/net/flow_control_test_base.hpp
@@ -33,10 +33,10 @@ static void TestSingleThreadPrefixSum(net::Group* net) {
     net::FlowControlChannelManager manager(*net, 1);
     net::FlowControlChannel& channel = manager.GetFlowControlChannel(0);
     size_t myRank = net->my_host_rank();
-    size_t zero = 0;
+    size_t initial = 0;
 
-    size_t resInclusive = channel.PrefixSum(myRank, zero, std::plus<size_t>(), true);
-    size_t resExclusive = channel.PrefixSum(myRank, zero, std::plus<size_t>(), false);
+    size_t resInclusive = channel.PrefixSum(myRank, initial, std::plus<size_t>(), true);
+    size_t resExclusive = channel.PrefixSum(myRank, initial, std::plus<size_t>(), false);
     size_t expectedInclusive = 0;
     size_t expectedExclusive = 0;
 
@@ -57,8 +57,8 @@ static void TestSingleThreadVectorPrefixSum(net::Group* net) {
     net::FlowControlChannel& channel = manager.GetFlowControlChannel(0);
     size_t size = 3;
     size_t myRank = net->my_host_rank();
-    std::vector<size_t> zero(size);
-    std::fill(zero.begin(), zero.end(), 0);
+    std::vector<size_t> initial(size);
+    std::fill(initial.begin(), initial.end(), 0);
     std::vector<size_t> val(size);
     std::fill(val.begin(), val.end(), myRank);
         
@@ -71,8 +71,8 @@ static void TestSingleThreadVectorPrefixSum(net::Group* net) {
             return res;
         };
 
-    std::vector<size_t> resInclusive = channel.PrefixSum(val, zero, addSizeTVectors, true);
-    std::vector<size_t> resExclusive = channel.PrefixSum(val, zero, addSizeTVectors, false);
+    std::vector<size_t> resInclusive = channel.PrefixSum(val, initial, addSizeTVectors, true);
+    std::vector<size_t> resExclusive = channel.PrefixSum(val, initial, addSizeTVectors, false);
     size_t expectedInclusive = 0;
     size_t expectedExclusive = 0;
 
@@ -190,10 +190,10 @@ static void TestMultiThreadPrefixSum(net::Group* net) {
     ExecuteMultiThreads(
         net, count, [=](net::FlowControlChannel& channel, size_t id) {
             size_t myRank = net->my_host_rank() * count + id;
-            size_t zero = 0;
+            size_t initial = 0;
 
-            size_t resInclusive = channel.PrefixSum(myRank, zero, std::plus<size_t>(), true);
-            size_t resExclusive = channel.PrefixSum(myRank, zero, std::plus<size_t>(), false);
+            size_t resInclusive = channel.PrefixSum(myRank, initial, std::plus<size_t>(), true);
+            size_t resExclusive = channel.PrefixSum(myRank, initial, std::plus<size_t>(), false);
             size_t expectedInclusive = 0;
             size_t expectedExclusive = 0;
 
@@ -220,13 +220,13 @@ static void TestHardcoreRaceConditionTest(net::Group* net) {
     ExecuteMultiThreads(
         net, count, [=](net::FlowControlChannel& channel, size_t id) {
             size_t myRank = net->my_host_rank() * count + id;
-            size_t zero = 0;
+            size_t initial = 0;
             std::vector<size_t> pres;
             std::vector<size_t> rres;
 
             for (int i = 0; i < 20; i++) {
                 // Make a prefix sum and push res
-                pres.push_back(channel.PrefixSum(myRank, zero));
+                pres.push_back(channel.PrefixSum(myRank, initial));
                 // Make an all reduce and push res.
                 rres.push_back(channel.AllReduce(myRank));
 

--- a/tests/net/group_test_base.hpp
+++ b/tests/net/group_test_base.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 using namespace thrill;      // NOLINT
+using namespace thrill::net::collective;
 
 //! do nothing but terminate, this check construction and destruction.
 static void TestNoOperation(net::Group*) { }
@@ -128,8 +129,8 @@ static void TestPrefixSumForPowersOfTwoString(net::Group* net) {
 
     std::string local_value = result.substr(net->my_host_rank(), 1);
     PrefixSumForPowersOfTwo(*net, local_value);
-    sLOG1 << "rank" << net->my_host_rank() << "hosts" << net->num_hosts()
-          << "value" << local_value;
+    //sLOG1 << "rank" << net->my_host_rank() << "hosts" << net->num_hosts()
+    //      << "value" << local_value;
     // ASSERT_EQ(result.substr(0, net->my_host_rank() + 1), local_value);
 }
 
@@ -208,7 +209,6 @@ static void DispatcherTestSyncSendAsyncRead(net::Group* net) {
 //! sleep for a new ticks until the dispatcher thread reaches select().
 static void TestDispatcherLaunchAndTerminate(net::Group* net) {
     mem::Manager mem_manager_(nullptr, "DispatcherTest");
-
     net::DispatcherThread disp(mem_manager_, *net, "dispatcher");
 
     // sleep for a new ticks until the dispatcher thread reaches select().

--- a/tests/net/mock_test.cpp
+++ b/tests/net/mock_test.cpp
@@ -101,6 +101,9 @@ TEST(MockGroup, DispatcherSyncSendAsyncRead) {
 TEST(FlowControlMockGroup, SingleThreadPrefixSum) {
     MockTestLess(TestSingleThreadPrefixSum);
 }
+TEST(FlowControlMockGroup, SingleThreadVectorPrefixSum) {
+    MockTestLess(TestSingleThreadVectorPrefixSum);
+}
 TEST(FlowControlMockGroup, SingleThreadBroadcast) {
     MockTestLess(TestSingleThreadBroadcast);
 }

--- a/tests/net/mock_test.cpp
+++ b/tests/net/mock_test.cpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 #include <thrill/common/logger.hpp>
 #include <thrill/net/collective_communication.hpp>
+#include <thrill/net/dispatcher_thread.hpp>
 #include <thrill/net/mock/group.hpp>
 
 #include <thread>

--- a/tests/net/tcp_test.cpp
+++ b/tests/net/tcp_test.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 #include <thrill/mem/manager.hpp>
+#include <thrill/net/dispatcher_thread.hpp>
 #include <thrill/net/tcp/group.hpp>
 #include <thrill/net/tcp/select_dispatcher.hpp>
 

--- a/tests/net/tcp_test.cpp
+++ b/tests/net/tcp_test.cpp
@@ -136,6 +136,9 @@ TEST(LocalTcpGroup, DispatcherSyncSendAsyncRead) {
 TEST(FlowControlLocalTcpGroup, SingleThreadPrefixSum) {
     LocalGroupTest(TestSingleThreadPrefixSum);
 }
+TEST(FlowControlLocalTcpGroup, SingleThreadVectorPrefixSum) {
+    LocalGroupTest(TestSingleThreadVectorPrefixSum);
+}
 TEST(FlowControlLocalTcpGroup, SingleThreadBroadcast) {
     LocalGroupTest(TestSingleThreadBroadcast);
 }

--- a/thrill/api/context.cpp
+++ b/thrill/api/context.cpp
@@ -14,6 +14,7 @@
 #include <thrill/common/cmdline_parser.hpp>
 #include <thrill/common/logger.hpp>
 #include <thrill/common/stats.hpp>
+#include <thrill/common/math.hpp>
 #include <thrill/net/tcp/construct.hpp>
 
 #include <atomic>
@@ -55,6 +56,13 @@ HostContext::ConstructLocalMock(size_t host_count, size_t workers_per_host) {
     }
 
     return host_context;
+}
+ 
+//! given a global range [0,global_size) and p PEs to split the range, calculate
+//! the [local_begin,local_end) index range assigned to the PE i. Takes the
+//! information from the Context.
+std::tuple<size_t, size_t> Context::CalculateLocalRange(size_t global_size) {
+    return common::CalculateLocalRange(global_size, num_workers(), my_rank());
 }
 
 /*!

--- a/thrill/api/context.hpp
+++ b/thrill/api/context.hpp
@@ -249,7 +249,7 @@ public:
     //! the [local_begin,local_end) index range assigned to the PE i. Takes the
     //! information from the Context.
     std::tuple<size_t, size_t> CalculateLocalRange(size_t global_size) {
-        return CalculateLocalRange(global_size, num_workers(), my_rank());
+        return common::CalculateLocalRange(global_size, num_workers(), my_rank());
     }
 
 private:

--- a/thrill/api/context.hpp
+++ b/thrill/api/context.hpp
@@ -16,7 +16,6 @@
 #include <thrill/api/stats_graph.hpp>
 #include <thrill/common/config.hpp>
 #include <thrill/common/stats.hpp>
-#include <thrill/common/math.hpp>
 #include <thrill/data/block_pool.hpp>
 #include <thrill/data/channel.hpp>
 #include <thrill/data/file.hpp>
@@ -248,9 +247,7 @@ public:
     //! given a global range [0,global_size) and p PEs to split the range, calculate
     //! the [local_begin,local_end) index range assigned to the PE i. Takes the
     //! information from the Context.
-    std::tuple<size_t, size_t> CalculateLocalRange(size_t global_size) {
-        return common::CalculateLocalRange(global_size, num_workers(), my_rank());
-    }
+    std::tuple<size_t, size_t> CalculateLocalRange(size_t global_size);
 
 private:
     //! host-global memory manager

--- a/thrill/api/context.hpp
+++ b/thrill/api/context.hpp
@@ -16,6 +16,7 @@
 #include <thrill/api/stats_graph.hpp>
 #include <thrill/common/config.hpp>
 #include <thrill/common/stats.hpp>
+#include <thrill/common/math.hpp>
 #include <thrill/data/block_pool.hpp>
 #include <thrill/data/channel.hpp>
 #include <thrill/data/file.hpp>
@@ -243,6 +244,13 @@ public:
 
     //! returns the host-global memory manager
     mem::Manager & mem_manager() { return mem_manager_; }
+
+    //! given a global range [0,global_size) and p PEs to split the range, calculate
+    //! the [local_begin,local_end) index range assigned to the PE i. Takes the
+    //! information from the Context.
+    std::tuple<size_t, size_t> CalculateLocalRange(size_t global_size) {
+        return CalculateLocalRange(global_size, num_workers(), my_rank());
+    }
 
 private:
     //! host-global memory manager

--- a/thrill/api/dia.hpp
+++ b/thrill/api/dia.hpp
@@ -511,11 +511,11 @@ public:
      *
      * \param sum_function Sum function (any associative function).
      *
-     * \param neutral_element Neutral element of the sum function.
+     * \param initial_element Initial element of the sum function.
      */
     template <typename SumFunction = std::plus<ValueType> >
     auto PrefixSum(const SumFunction& sum_function = SumFunction(),
-                   ValueType neutral_element = ValueType()) const;
+                   ValueType initial_element = ValueType()) const;
 
     /*!
      * Sort is a DOp, which sorts a given DIA according to the given compare_function.

--- a/thrill/api/distribute.hpp
+++ b/thrill/api/distribute.hpp
@@ -15,7 +15,6 @@
 #include <thrill/api/dia.hpp>
 #include <thrill/api/source_node.hpp>
 #include <thrill/common/logger.hpp>
-#include <thrill/common/math.hpp>
 
 #include <string>
 #include <vector>
@@ -50,7 +49,7 @@ public:
     void PushData(bool /* consume */) final {
         size_t local_begin, local_end;
         std::tie(local_begin, local_end) =
-            common::CalculateLocalRange(in_vector_.size(), context_);
+            context_.CalculateLocalRange(in_vector_.size());
 
         for (size_t i = local_begin; i < local_end; ++i) {
             this->PushItem(in_vector_[i]);

--- a/thrill/api/distribute_from.hpp
+++ b/thrill/api/distribute_from.hpp
@@ -15,7 +15,6 @@
 #include <thrill/api/dia.hpp>
 #include <thrill/api/source_node.hpp>
 #include <thrill/common/logger.hpp>
-#include <thrill/common/math.hpp>
 
 #include <string>
 #include <vector>

--- a/thrill/api/generate.hpp
+++ b/thrill/api/generate.hpp
@@ -68,7 +68,7 @@ public:
     void PushData(bool /* consume */) final {
         size_t local_begin, local_end;
         std::tie(local_begin, local_end) =
-            common::CalculateLocalRange(size_, context_);
+            common::CalculateLocalRange(size_, context_.num_workers(), context_.my_rank());
 
         for (size_t i = local_begin; i < local_end; i++) {
             this->PushItem(generator_function_(i));

--- a/thrill/api/generate.hpp
+++ b/thrill/api/generate.hpp
@@ -17,7 +17,6 @@
 #include <thrill/api/dia.hpp>
 #include <thrill/api/source_node.hpp>
 #include <thrill/common/logger.hpp>
-#include <thrill/common/math.hpp>
 #include <thrill/common/stat_logger.hpp>
 
 #include <fstream>

--- a/thrill/api/generate.hpp
+++ b/thrill/api/generate.hpp
@@ -67,8 +67,7 @@ public:
 
     void PushData(bool /* consume */) final {
         size_t local_begin, local_end;
-        std::tie(local_begin, local_end) =
-            common::CalculateLocalRange(size_, context_.num_workers(), context_.my_rank());
+        std::tie(local_begin, local_end) = context_.CalculateLocalRange(size_);
 
         for (size_t i = local_begin; i < local_end; i++) {
             this->PushItem(generator_function_(i));

--- a/thrill/api/prefixsum.hpp
+++ b/thrill/api/prefixsum.hpp
@@ -39,12 +39,12 @@ class PrefixSumNode : public DOpNode<ValueType>
 public:
     PrefixSumNode(const ParentDIARef& parent,
                   SumFunction sum_function,
-                  ValueType neutral_element,
+                  ValueType initial_element,
                   StatsNode* stats_node)
         : DOpNode<ValueType>(parent.ctx(), { parent.node() }, stats_node),
           sum_function_(sum_function),
-          local_sum_(neutral_element),
-          neutral_element_(neutral_element)
+          local_sum_(initial_element),
+          initial_element_(initial_element)
     {
         // Hook PreOp(s)
         auto pre_op_fn = [=](const ValueType& input) {
@@ -90,8 +90,8 @@ private:
     SumFunction sum_function_;
     //! Local sum to be used in all reduce operation.
     ValueType local_sum_;
-    //! Neutral element.
-    ValueType neutral_element_;
+    //! Initial element.
+    ValueType initial_element_;
 
     //! Local data file
     data::File file_ { context_.GetFile() };
@@ -111,10 +111,11 @@ private:
         LOG << "MainOp processing";
         net::FlowControlChannel& channel = context_.flow_control_channel();
 
-        ValueType sum = channel.PrefixSum(local_sum_, neutral_element_, sum_function_, false);
+        ValueType sum = channel.PrefixSum(local_sum_, initial_element_,
+                                          sum_function_, false);
 
         if (context_.my_rank() == 0) {
-            sum = neutral_element_;
+            sum = initial_element_;
         }
 
         local_sum_ = sum;
@@ -126,7 +127,7 @@ private:
 template <typename ValueType, typename Stack>
 template <typename SumFunction>
 auto DIARef<ValueType, Stack>::PrefixSum(
-    const SumFunction &sum_function, ValueType neutral_element) const {
+    const SumFunction &sum_function, ValueType initial_element) const {
     assert(IsValid());
 
     using SumResultNode
@@ -155,7 +156,7 @@ auto DIARef<ValueType, Stack>::PrefixSum(
     auto shared_node
         = std::make_shared<SumResultNode>(*this,
                                           sum_function,
-                                          neutral_element,
+                                          initial_element,
                                           stats_node);
 
     auto sum_stack = shared_node->ProduceStack();

--- a/thrill/api/prefixsum.hpp
+++ b/thrill/api/prefixsum.hpp
@@ -111,7 +111,7 @@ private:
         LOG << "MainOp processing";
         net::FlowControlChannel& channel = context_.flow_control_channel();
 
-        ValueType sum = channel.PrefixSum(local_sum_, sum_function_, false);
+        ValueType sum = channel.PrefixSum(local_sum_, neutral_element_, sum_function_, false);
 
         if (context_.my_rank() == 0) {
             sum = neutral_element_;

--- a/thrill/api/read_binary.hpp
+++ b/thrill/api/read_binary.hpp
@@ -14,10 +14,10 @@
 #define THRILL_API_READ_BINARY_HEADER
 
 #include <thrill/api/dia.hpp>
+#include <thrill/api/context.hpp>
 #include <thrill/api/source_node.hpp>
 #include <thrill/common/item_serialization_tools.hpp>
 #include <thrill/common/logger.hpp>
-#include <thrill/common/math.hpp>
 #include <thrill/core/file_io.hpp>
 #include <thrill/data/block.hpp>
 #include <thrill/data/block_reader.hpp>
@@ -66,9 +66,7 @@ public:
 
         size_t my_start, my_end;
         std::tie(my_start, my_end) =
-            common::CalculateLocalRange(filelist_[filelist_.size() - 1].second,
-                                        context_.num_workers(),
-                                        context_.my_rank());
+            context_.CalculateLocalRange(filelist_[filelist_.size() - 1].second);
         size_t first_file = 0;
         size_t last_file = 0;
 

--- a/thrill/api/read_lines.hpp
+++ b/thrill/api/read_lines.hpp
@@ -14,10 +14,10 @@
 #define THRILL_API_READ_LINES_HEADER
 
 #include <thrill/api/dia.hpp>
+#include <thrill/api/context.hpp>
 #include <thrill/api/source_node.hpp>
 #include <thrill/common/defines.hpp>
 #include <thrill/common/logger.hpp>
-#include <thrill/common/math.hpp>
 #include <thrill/common/stat_logger.hpp>
 #include <thrill/common/string.hpp>
 #include <thrill/common/system_exception.hpp>
@@ -180,7 +180,7 @@ private:
             // Go to start of 'local part'.
             size_t my_start;
             std::tie(my_start, my_end_) =
-                common::CalculateLocalRange(files[NumFiles()].second, ctx.num_workers(), ctx.my_rank());
+                context_.CalculateLocalRange(files[NumFiles()].second);
 
             while (files_[current_file_ + 1].second <= my_start) {
                 current_file_++;
@@ -300,7 +300,7 @@ private:
             // Go to start of 'local part'.
             size_t my_start;
             std::tie(my_start, my_end_) =
-                common::CalculateLocalRange(files[NumFiles()].second, ctx.num_workers(), ctx.my_rank());
+                context_.CalculateLocalRange(files[NumFiles()].second);
 
             while (files_[current_file_ + 1].second <= my_start) {
                 current_file_++;

--- a/thrill/api/reduce_to_index.hpp
+++ b/thrill/api/reduce_to_index.hpp
@@ -16,10 +16,10 @@
 #define THRILL_API_REDUCE_TO_INDEX_HEADER
 
 #include <thrill/api/dia.hpp>
+#include <thrill/api/context.hpp>
 #include <thrill/api/dop_node.hpp>
 #include <thrill/common/functional.hpp>
 #include <thrill/common/logger.hpp>
-#include <thrill/common/math.hpp>
 #include <thrill/core/reduce_post_table.hpp>
 #include <thrill/core/reduce_pre_table.hpp>
 
@@ -140,7 +140,7 @@ public:
 
         size_t local_begin, local_end;
 
-        std::tie(local_begin, local_end) = common::CalculateLocalRange(result_size_, context_);
+        std::tie(local_begin, local_end) = context_.CalculateLocalRange(result_size_);
 
         std::vector<std::function<void(const ValueType&)> > cbs;
         DIANode<ValueType>::callback_functions(cbs);

--- a/thrill/api/sort.hpp
+++ b/thrill/api/sort.hpp
@@ -290,8 +290,7 @@ private:
     void MainOp() {
         net::FlowControlChannel& channel = context_.flow_control_channel();
 
-        size_t zero = 0;
-        size_t prefix_elem = channel.PrefixSum(data_.size(), zero);
+        size_t prefix_elem = channel.PrefixSum(data_.size());
         size_t total_elem = channel.AllReduce(data_.size());
 
         size_t num_total_workers = context_.num_workers();

--- a/thrill/api/sort.hpp
+++ b/thrill/api/sort.hpp
@@ -15,9 +15,9 @@
 #define THRILL_API_SORT_HEADER
 
 #include <thrill/api/dia.hpp>
+#include <thrill/api/context.hpp>
 #include <thrill/api/dop_node.hpp>
 #include <thrill/common/logger.hpp>
-#include <thrill/common/math.hpp>
 #include <thrill/net/flow_control_channel.hpp>
 #include <thrill/net/flow_control_manager.hpp>
 #include <thrill/net/group.hpp>

--- a/thrill/api/sort.hpp
+++ b/thrill/api/sort.hpp
@@ -290,7 +290,8 @@ private:
     void MainOp() {
         net::FlowControlChannel& channel = context_.flow_control_channel();
 
-        size_t prefix_elem = channel.PrefixSum(data_.size());
+        size_t zero = 0;
+        size_t prefix_elem = channel.PrefixSum(data_.size(), zero);
         size_t total_elem = channel.AllReduce(data_.size());
 
         size_t num_total_workers = context_.num_workers();

--- a/thrill/api/write_binary.hpp
+++ b/thrill/api/write_binary.hpp
@@ -14,8 +14,8 @@
 #define THRILL_API_WRITE_BINARY_HEADER
 
 #include <thrill/api/action_node.hpp>
+#include <thrill/api/context.hpp>
 #include <thrill/api/dia.hpp>
-#include <thrill/common/math.hpp>
 #include <thrill/common/stat_logger.hpp>
 #include <thrill/common/string.hpp>
 #include <thrill/core/file_io.hpp>

--- a/thrill/api/write_lines.hpp
+++ b/thrill/api/write_lines.hpp
@@ -72,7 +72,8 @@ public:
                        << "TotalLines" << stats_total_elements_;
 
         // (Portable) allocation of output file, setting individual file pointers.
-        size_t prefix_elem = context_.flow_control_channel().ExPrefixSum(size_);
+        size_t zero = 0;
+        size_t prefix_elem = context_.flow_control_channel().ExPrefixSum(size_, zero);
         if (context_.my_rank() == context_.num_workers() - 1) {
             file_.seekp(prefix_elem + size_ - 1);
             file_.put('\0');

--- a/thrill/api/write_lines.hpp
+++ b/thrill/api/write_lines.hpp
@@ -72,8 +72,7 @@ public:
                        << "TotalLines" << stats_total_elements_;
 
         // (Portable) allocation of output file, setting individual file pointers.
-        size_t zero = 0;
-        size_t prefix_elem = context_.flow_control_channel().ExPrefixSum(size_, zero);
+        size_t prefix_elem = context_.flow_control_channel().ExPrefixSum(size_);
         if (context_.my_rank() == context_.num_workers() - 1) {
             file_.seekp(prefix_elem + size_ - 1);
             file_.put('\0');

--- a/thrill/api/write_lines_many.hpp
+++ b/thrill/api/write_lines_many.hpp
@@ -16,6 +16,7 @@
 
 #include <thrill/api/action_node.hpp>
 #include <thrill/api/dia.hpp>
+#include <thrill/common/math.hpp>
 #include <thrill/core/file_io.hpp>
 #include <thrill/core/stage_builder.hpp>
 #include <thrill/net/buffer_builder.hpp>

--- a/thrill/api/zip.hpp
+++ b/thrill/api/zip.hpp
@@ -265,10 +265,11 @@ private:
             //! number of elements of this worker
             size_t dia_local_size = files_[in].num_items();
             sLOG << "input" << in << "dia_local_size" << dia_local_size;
+            size_t zero = 0; //Force type. 
 
             //! inclusive prefixsum of number of elements: we have items from
             //! [dia_size_prefixsum - local_size, dia_size_prefixsum).
-            dia_size_prefixsum_[in] = channel.PrefixSum(dia_local_size);
+            dia_size_prefixsum_[in] = channel.PrefixSum(dia_local_size, zero);
 
             //! total number of elements, over all worker. TODO(tb): use a
             //! Broadcast from the last node instead.

--- a/thrill/api/zip.hpp
+++ b/thrill/api/zip.hpp
@@ -265,11 +265,10 @@ private:
             //! number of elements of this worker
             size_t dia_local_size = files_[in].num_items();
             sLOG << "input" << in << "dia_local_size" << dia_local_size;
-            size_t zero = 0; //Force type. 
 
             //! inclusive prefixsum of number of elements: we have items from
             //! [dia_size_prefixsum - local_size, dia_size_prefixsum).
-            dia_size_prefixsum_[in] = channel.PrefixSum(dia_local_size, zero);
+            dia_size_prefixsum_[in] = channel.PrefixSum(dia_local_size);
 
             //! total number of elements, over all worker. TODO(tb): use a
             //! Broadcast from the last node instead.

--- a/thrill/common/math.hpp
+++ b/thrill/common/math.hpp
@@ -22,7 +22,7 @@ namespace common {
 
 //! calculate the log2 floor of an integer type (by repeated bit shifts)
 template <typename IntegerType>
-unsigned int IntegerLog2Floor(IntegerType i) {
+static inline unsigned int IntegerLog2Floor(IntegerType i) {
     unsigned int p = 0;
     while (i >= 256) i >>= 8, p += 8;
     while (i >>= 1) ++p;
@@ -31,7 +31,7 @@ unsigned int IntegerLog2Floor(IntegerType i) {
 
 //! calculate the log2 ceiling of an integer type (by repeated bit shifts)
 template <typename IntegerType>
-unsigned int IntegerLog2Ceil(const IntegerType& i) {
+static inline unsigned int IntegerLog2Ceil(const IntegerType& i) {
     if (i <= 1) return 0;
     return IntegerLog2Floor(i - 1) + 1;
 }
@@ -57,7 +57,7 @@ static inline Integral RoundDownToPowerOfTwo(Integral n) {
 
 //! calculate n div k with rounding up
 template <typename IntegerType>
-IntegerType IntegerDivRoundUp(const IntegerType& n, const IntegerType& k) {
+static inline IntegerType IntegerDivRoundUp(const IntegerType& n, const IntegerType& k) {
     return (n + k - 1) / k;
 }
 
@@ -65,7 +65,7 @@ IntegerType IntegerDivRoundUp(const IntegerType& n, const IntegerType& k) {
 
 //! given a global range [0,global_size) and p PEs to split the range, calculate
 //! the [local_begin,local_end) index range assigned to the PE i.
-std::tuple<size_t, size_t> CalculateLocalRange(
+static inline std::tuple<size_t, size_t> CalculateLocalRange(
     size_t global_size, size_t p, size_t i) {
 
     double per_pe = static_cast<double>(global_size) / static_cast<double>(p);

--- a/thrill/common/math.hpp
+++ b/thrill/common/math.hpp
@@ -12,8 +12,6 @@
 #ifndef THRILL_COMMON_MATH_HEADER
 #define THRILL_COMMON_MATH_HEADER
 
-#include <thrill/api/context.hpp>
-
 #include <algorithm>
 #include <tuple>
 
@@ -76,14 +74,6 @@ std::tuple<size_t, size_t> CalculateLocalRange(
         std::min(static_cast<size_t>(
                      std::ceil(static_cast<double>(i + 1) * per_pe)),
                  global_size));
-}
-
-//! given a global range [0,global_size) and p PEs to split the range, calculate
-//! the [local_begin,local_end) index range assigned to the PE i. Takes the
-//! information from the Context.
-std::tuple<size_t, size_t> CalculateLocalRange(
-    size_t global_size, const Context& ctx) {
-    return CalculateLocalRange(global_size, ctx.num_workers(), ctx.my_rank());
 }
 
 /******************************************************************************/

--- a/thrill/net/collective_communication.hpp
+++ b/thrill/net/collective_communication.hpp
@@ -26,7 +26,7 @@
 
 namespace thrill {
 namespace net {
-namespace collective_communication {
+namespace collective {
 
 //! \addtogroup net Network Communication
 //! \{
@@ -292,7 +292,7 @@ static void PrefixSum(Group& net, T& value, BinarySumOp sumOp = BinarySumOp(), b
 
 //! \}
 
-} // namespace collective_communication
+} // namespace collective
 } // namespace net
 } // namespace thrill
 

--- a/thrill/net/collective_communication.hpp
+++ b/thrill/net/collective_communication.hpp
@@ -183,7 +183,7 @@ void BroadcastBinomialTree(Group& net, T& value) {
  */
 template <typename T>
 void Broadcast(Group& net, T& value) {
-    BroadcastBinomialTree(net, value);
+   return BroadcastBinomialTree(net, value);
 }
 
 //! \brief   Perform an All-Reduce on the workers.

--- a/thrill/net/collective_communication.hpp
+++ b/thrill/net/collective_communication.hpp
@@ -265,7 +265,9 @@ static inline void ThreadBarrier(std::mutex& mtx, std::condition_variable& cv, i
 //! \param   value The value to be summed up
 //! \param   sumOp A custom summation operator
 template <typename T, typename BinarySumOp = std::plus<T> >
-static inline void PrefixSum(Group& net, T& value, BinarySumOp sumOp = BinarySumOp(), bool inclusive = true) {
+static inline void PrefixSum(
+    Group& net, T& value,
+    BinarySumOp sumOp = BinarySumOp(), bool inclusive = true) {
     static const bool debug = false;
 
     bool first = true;

--- a/thrill/net/collective_communication.hpp
+++ b/thrill/net/collective_communication.hpp
@@ -18,8 +18,6 @@
 
 #include <thrill/common/functional.hpp>
 #include <thrill/common/math.hpp>
-
-
 #include <thrill/net/group.hpp>
 
 #include <functional>

--- a/thrill/net/collective_communication.hpp
+++ b/thrill/net/collective_communication.hpp
@@ -21,6 +21,8 @@
 #include <thrill/net/group.hpp>
 
 #include <functional>
+#include <mutex>
+#include <condition_variable>
 
 namespace thrill {
 namespace net {
@@ -232,6 +234,7 @@ static inline void AllReduceForPowersOfTwo(Group& net, T& value, BinarySumOp sum
     sLOG << "ALL_REDUCE_HYPERCUBE: value after all reduce " << value << "\n";
 }
 
+#if DISABLE_MAYBE_REMOVE
 //! \brief   Perform a barrier for all workers.
 //! \details All workers synchronize to this point. This operation can be used if
 //!          one wants to be sure that all workers continue their operation
@@ -251,6 +254,7 @@ static inline void ThreadBarrier(std::mutex& mtx, std::condition_variable& cv, i
         cv.notify_all();
     }
 }
+#endif
 
 //! \brief   Calculate for every worker his prefix sum.
 //! \details The prefix sum is the aggregatation of the values of all workers
@@ -295,7 +299,6 @@ static inline void PrefixSum(Group& net, T& value, BinarySumOp sumOp = BinarySum
         }
     }
 }
-
 //! \}
 
 } // namespace collective

--- a/thrill/net/collective_communication.hpp
+++ b/thrill/net/collective_communication.hpp
@@ -44,7 +44,7 @@ namespace collective {
  * \param sum_op A custom summation operator
  */
 template <typename T, typename BinarySumOp = std::plus<T> >
-static void PrefixSumForPowersOfTwo(
+static inline void PrefixSumForPowersOfTwo(
     Group& net, T& value, BinarySumOp sum_op = BinarySumOp()) {
     T total_sum = value;
 
@@ -94,7 +94,7 @@ static void PrefixSumForPowersOfTwo(
  * \param sum_op A custom summation operator
  */
 template <typename T, typename BinarySumOp = std::plus<T> >
-void ReduceToRoot(Group& net, T& value, BinarySumOp sum_op = BinarySumOp()) {
+static inline void ReduceToRoot(Group& net, T& value, BinarySumOp sum_op = BinarySumOp()) {
     bool active = true;
     for (size_t d = 1; d < net.num_hosts(); d <<= 1) {
         if (active) {
@@ -120,7 +120,7 @@ void ReduceToRoot(Group& net, T& value, BinarySumOp sum_op = BinarySumOp()) {
  * \param value The value to be broadcast / receive into.
  */
 template <typename T>
-void BroadcastTrivial(Group& net, T& value) {
+static inline void BroadcastTrivial(Group& net, T& value) {
 
     if (net.my_host_rank() == 0) {
         // send value to all peers
@@ -192,7 +192,7 @@ void Broadcast(Group& net, T& value) {
 //! \param   value The value to be added to the aggregation
 //! \param   sumOp A custom summation operator
 template <typename T, typename BinarySumOp = std::plus<T> >
-void AllReduce(Group& net, T& value, BinarySumOp sumOp = BinarySumOp()) {
+static inline void AllReduce(Group& net, T& value, BinarySumOp sumOp = BinarySumOp()) {
     ReduceToRoot(net, value, sumOp);
     Broadcast(net, value);
 }
@@ -204,7 +204,7 @@ void AllReduce(Group& net, T& value, BinarySumOp sumOp = BinarySumOp()) {
 //! \param   value The value to be added to the aggregation
 //! \param   sumOp A custom summation operator
 template <typename T, typename BinarySumOp = std::plus<T> >
-void AllReduceForPowersOfTwo(Group& net, T& value, BinarySumOp sumOp = BinarySumOp()) {
+static inline void AllReduceForPowersOfTwo(Group& net, T& value, BinarySumOp sumOp = BinarySumOp()) {
     // For each dimension of the hypercube, exchange data between workers with
     // different bits at position d
 
@@ -240,8 +240,7 @@ void AllReduceForPowersOfTwo(Group& net, T& value, BinarySumOp sumOp = BinarySum
 //! \param   mtx A common mutex onto which to lock
 //! \param   cv  A condition variable which locks on the given mutex
 //! \param   num_workers The total number of workers in the network
-static inline
-void ThreadBarrier(std::mutex& mtx, std::condition_variable& cv, int& num_workers) {
+static inline void ThreadBarrier(std::mutex& mtx, std::condition_variable& cv, int& num_workers) {
     std::unique_lock<std::mutex> lck(mtx);
     if (num_workers > 1) {
         --num_workers;
@@ -262,7 +261,7 @@ void ThreadBarrier(std::mutex& mtx, std::condition_variable& cv, int& num_worker
 //! \param   value The value to be summed up
 //! \param   sumOp A custom summation operator
 template <typename T, typename BinarySumOp = std::plus<T> >
-static void PrefixSum(Group& net, T& value, BinarySumOp sumOp = BinarySumOp(), bool inclusive = true) {
+static inline void PrefixSum(Group& net, T& value, BinarySumOp sumOp = BinarySumOp(), bool inclusive = true) {
     static const bool debug = false;
 
     bool first = true;

--- a/thrill/net/flow_control_channel.hpp
+++ b/thrill/net/flow_control_channel.hpp
@@ -182,7 +182,7 @@ public:
 
             T prefixSumBase = localPrefixBuffer[threadCount - 1];
 
-            collective_communication::PrefixSum(group, prefixSumBase, sumOp, false);
+            collective::PrefixSum(group, prefixSumBase, sumOp, false);
 
             if(inclusive) {
                 for (size_t i = 0; i < threadCount; i++) {
@@ -244,7 +244,7 @@ public:
         if (threadId == 0) {
             SetLocalShared(&res);
 
-            collective_communication::Broadcast(group, res);
+            collective::Broadcast(group, res);
         }
 
         barrier.Await();
@@ -293,7 +293,7 @@ public:
                 res = sumOp(res, localReduceBuffer[i]);
             }
 
-            collective_communication::AllReduce(group, res, sumOp);
+            collective::AllReduce(group, res, sumOp);
 
             ClearLocalShared();
             SetLocalShared(&res);


### PR DESCRIPTION
Also some nice changes to prefix sum (Zero element, use log-n-prefix sum also in two-level scheme, exclusive prefix sum actually works now, fixed associativity that was vice-versa in collective-communication). 

Also some further small improvements Timo suggested. 

Also some new tests that include exclusive prefix sums. 