### PR TITLE
Move semantics fixes

### DIFF
--- a/thrill/common/aggregate.hpp
+++ b/thrill/common/aggregate.hpp
@@ -35,12 +35,12 @@ public:
 
     //! initializing constructor
     Aggregate(size_t count, const Type& total,
-              const Type& min, const Type& max, const Type& total_squares)
+              const Type& min, const Type& max, const Type& total_squares) noexcept
         : count_(count), total_(total),
           min_(min), max_(max), total_squares_(total_squares) { }
 
     //! add a value to the running aggregation
-    Aggregate & Add(const Type& value) {
+    Aggregate & Add(const Type& value) noexcept {
         count_++;
         total_ += value;
         min_ = std::min(min_, value);
@@ -50,13 +50,14 @@ public:
     }
 
     //! return number of values aggregated
-    size_t Count() const { return count_; }
+    size_t Count() const noexcept { return count_; }
 
     //! return sum over all values aggregated
-    const Type & Total() const { return total_; }
+    const Type & Total() const noexcept { return total_; }
 
     //! return the average over all values aggregated
     double Average() const {
+        // can't make noexcept since _Type's conversion is allowed to throw
         return static_cast<double>(total_) / static_cast<double>(count_);
     }
 
@@ -64,13 +65,13 @@ public:
     double Avg() const { return Average(); }
 
     //! return minimum over all values aggregated
-    const Type & Min() const { return min_; }
+    const Type & Min() const noexcept { return min_; }
 
     //! return maximum over all values aggregated
-    const Type & Max() const { return max_; }
+    const Type & Max() const noexcept { return max_; }
 
     //! return sum over all squared values aggregated
-    const Type & TotalSquares() const { return total_squares_; }
+    const Type & TotalSquares() const noexcept { return total_squares_; }
 
     //! return the standard deviation of all values aggregated
     double StandardDeviation() const {
@@ -85,14 +86,14 @@ public:
     double StdDev() const { return StandardDeviation(); }
 
     //! operator +
-    Aggregate operator + (const Aggregate& a) const {
+    Aggregate operator + (const Aggregate& a) const noexcept {
         return Aggregate(count_ + a.count_, total_ + a.total_,
                          std::min(min_, a.min_), std::max(max_, a.max_),
                          total_squares_ + a.total_squares_);
     }
 
     //! operator +=
-    Aggregate& operator += (const Aggregate& a) {
+    Aggregate& operator += (const Aggregate& a) noexcept {
         count_ += a.count_;
         total_ += a.total_;
         min_ = std::min(min_, a.min_);

--- a/thrill/common/atomic_movable.hpp
+++ b/thrill/common/atomic_movable.hpp
@@ -47,11 +47,11 @@ public:
     //! move-construction NOT same as std::atomic: load and move.
     //! Requires T to have an ctor that takes an instance of T for
     //! initialization.
-    AtomicMovable(const AtomicMovable&& rhs)
+    AtomicMovable(const AtomicMovable&& rhs) noexcept
         : std::atomic<T>(T(std::move(rhs))) { }
 
     //! assignment operator (same as std::atomic)
-    T operator = (T desired) { return std::atomic<T>::operator = (desired); }
+    T operator = (T desired) noexcept { return std::atomic<T>::operator = (desired); }
 };
 
 } // namespace common

--- a/thrill/common/concurrent_bounded_queue.hpp
+++ b/thrill/common/concurrent_bounded_queue.hpp
@@ -89,7 +89,7 @@ public:
     template <typename ... Arguments>
     void emplace(Arguments&& ... args) {
         std::unique_lock<std::mutex> lock(mutex_);
-        queue_.emplace(args ...);
+        queue_.emplace(std::forward<Arguments>(args)...);
         cv_.notify_one();
     }
 

--- a/thrill/common/concurrent_queue.hpp
+++ b/thrill/common/concurrent_queue.hpp
@@ -76,7 +76,7 @@ public:
     template <typename ... Arguments>
     void emplace(Arguments&& ... args) {
         std::unique_lock<std::mutex> lock(mutex_);
-        queue_.emplace_back(args ...);
+        queue_.emplace_back(std::forward<Arguments>(args)...);
     }
 
     //! Returns: true if queue has no items; false otherwise.

--- a/thrill/common/counting_ptr.hpp
+++ b/thrill/common/counting_ptr.hpp
@@ -86,26 +86,26 @@ public:
     friend class CountingPtr;
 
     //! default constructor: contains a nullptr pointer.
-    CountingPtr() : ptr_(nullptr)
+    CountingPtr() noexcept : ptr_(nullptr)
     { }
 
     //! constructor with pointer: initializes new reference to ptr.
-    explicit CountingPtr(Type* ptr) : ptr_(ptr)
+    explicit CountingPtr(Type* ptr) noexcept : ptr_(ptr)
     { IncReference(); }
 
     //! copy-constructor: also initializes new reference to ptr.
-    CountingPtr(const CountingPtr& other_ptr) : ptr_(other_ptr.ptr_)
+    CountingPtr(const CountingPtr& other_ptr) noexcept : ptr_(other_ptr.ptr_)
     { IncReference(); }
 
     //! move-constructor: just moves pointer, does not change reference counts.
-    CountingPtr(CountingPtr&& other_ptr) : ptr_(other_ptr.ptr_) {
+    CountingPtr(CountingPtr&& other_ptr) noexcept : ptr_(other_ptr.ptr_) {
         other_ptr.ptr_ = nullptr;
     }
 
     //! move-constructor from other counting pointer (pointer types must be
     //! convertible): also initializes new reference to ptr.
     template <typename Other>
-    CountingPtr(CountingPtr<Other>&& other_ptr) : ptr_(other_ptr.ptr_)
+    CountingPtr(CountingPtr<Other>&& other_ptr) noexcept : ptr_(other_ptr.ptr_)
     { other_ptr.ptr_ = nullptr; }
 
     //! copy-assignment operator: dereference current object and acquire
@@ -221,15 +221,15 @@ private:
 
 public:
     //! new objects have zero reference count
-    ReferenceCount()
+    ReferenceCount() noexcept
         : reference_count_(0) { }
 
     //! coping still creates a new object with zero reference count
-    ReferenceCount(const ReferenceCount&)
+    ReferenceCount(const ReferenceCount&) noexcept
         : reference_count_(0) { }
 
     //! assignment operator, leaves pointers unchanged
-    ReferenceCount& operator = (const ReferenceCount&)
+    ReferenceCount& operator = (const ReferenceCount&) noexcept
     { return *this; } // changing the contents leaves pointers unchanged
 
     ~ReferenceCount()

--- a/thrill/common/future.hpp
+++ b/thrill/common/future.hpp
@@ -81,14 +81,14 @@ public:
     }
 
     //! Returns true when the future was fulfilled.
-    bool Test() const {
+    bool Test() const noexcept {
         return triggered_;
     }
 
     //! Indicates if get was invoked and returned
     //! Can be used at the end of a job to see if outstanding
     //! futures were not called.
-    bool is_finished() const {
+    bool is_finished() const noexcept {
         return finished_;
     }
 };
@@ -162,7 +162,7 @@ public:
     //! Indicates if get was invoked and returned
     //! Can be used at the end of a job to see if outstanding
     //! futures were not called.
-    bool is_finished() const {
+    bool is_finished() const noexcept {
         return finished_;
     }
 };

--- a/thrill/common/timed_counter.hpp
+++ b/thrill/common/timed_counter.hpp
@@ -30,7 +30,7 @@ public:
     TimedCounter(const TimedCounter& that) = delete;
     // move is okay
     TimedCounter(TimedCounter&& rhs) {
-        occurences_ = rhs.occurences_;
+        occurences_ = std::move(rhs.occurences_);
     }
 
     TimedCounter() { }

--- a/thrill/core/file_io.hpp
+++ b/thrill/core/file_io.hpp
@@ -100,7 +100,7 @@ public:
     //! non-copyable: delete assignment operator
     SysFile& operator = (const SysFile&) = delete;
     //! move-constructor
-    SysFile(SysFile&& f)
+    SysFile(SysFile&& f) noexcept
         : fd_(f.fd_), pid_(f.pid_) {
         f.fd_ = -1, f.pid_ = 0;
     }
@@ -147,7 +147,7 @@ public:
 
 private:
     //! private constructor: use OpenForRead or OpenForWrite.
-    explicit SysFile(int fd, int pid = 0)
+    explicit SysFile(int fd, int pid = 0) noexcept
         : fd_(fd), pid_(pid) { }
 
     //! file descriptor

--- a/thrill/net/buffer.hpp
+++ b/thrill/net/buffer.hpp
@@ -65,12 +65,12 @@ public:
     //! \{
 
     //! allocate empty buffer
-    Buffer()
+    Buffer() noexcept
         : data_(nullptr), size_(0)
     { }
 
     //! allocate buffer containing n bytes
-    explicit Buffer(size_type n)
+    explicit Buffer(size_type n) noexcept
         : Buffer(true, malloc(n), n)
     { }
 
@@ -87,14 +87,14 @@ public:
     Buffer& operator = (const Buffer&) = delete;
 
     //! move-construct other buffer into this one
-    Buffer(Buffer&& other)
+    Buffer(Buffer&& other) noexcept
         : data_(other.data_), size_(other.size_) {
         other.data_ = nullptr;
         other.size_ = 0;
     }
 
     //! move-assignment of other buffer into this one
-    Buffer& operator = (Buffer&& other) {
+    Buffer& operator = (Buffer&& other) noexcept {
         if (this != &other) {
             if (data_) free(data_);
             data_ = other.data_;
@@ -123,7 +123,7 @@ public:
     }
 
     //! Check for Buffer contents is valid.
-    bool IsValid() const { return (data_ != nullptr); }
+    bool IsValid() const noexcept { return (data_ != nullptr); }
 
     //! \}
 
@@ -131,14 +131,14 @@ public:
     //! \{
 
     //! return iterator to beginning of Buffer
-    iterator data()
+    iterator data() noexcept
     { return data_; }
     //! return iterator to beginning of Buffer
-    const_iterator data() const
+    const_iterator data() const noexcept
     { return data_; }
 
     //! return number of items in Buffer
-    size_type size() const
+    size_type size() const noexcept
     { return size_; }
 
     //! return the i-th position of the Buffer
@@ -157,23 +157,23 @@ public:
     //! \name Iterator Access
 
     //! return mutable iterator to first element
-    iterator begin()
+    iterator begin() noexcept
     { return data_; }
     //! return constant iterator to first element
-    const_iterator begin() const
+    const_iterator begin() const noexcept
     { return data_; }
     //! return constant iterator to first element
-    const_iterator cbegin() const
+    const_iterator cbegin() const noexcept
     { return begin(); }
 
     //! return mutable iterator beyond last element
-    iterator end()
+    iterator end() noexcept
     { return data_ + size_; }
     //! return constant iterator beyond last element
-    const_iterator end() const
+    const_iterator end() const noexcept
     { return data_ + size_; }
     //! return constant iterator beyond last element
-    const_iterator cend() const
+    const_iterator cend() const noexcept
     { return end(); }
 
     //! \}

--- a/thrill/net/buffer_builder.hpp
+++ b/thrill/net/buffer_builder.hpp
@@ -75,7 +75,7 @@ public:
     }
 
     //! Move-Constructor, moves memory area.
-    BufferBuilder(BufferBuilder&& other)
+    BufferBuilder(BufferBuilder&& other) noexcept
         : data_(other.data_), size_(other.size_), capacity_(other.capacity_) {
         other.data_ = nullptr;
         other.size_ = 0;
@@ -106,7 +106,7 @@ public:
     }
 
     //! Move-Assignment operator: move other's memory area into buffer.
-    BufferBuilder& operator = (BufferBuilder&& other) {
+    BufferBuilder& operator = (BufferBuilder&& other) noexcept {
         if (this != &other)
         {
             if (data_) free(data_);

--- a/thrill/net/manager.hpp
+++ b/thrill/net/manager.hpp
@@ -61,7 +61,7 @@ public:
     /*!
      * Construct Manager from already initialized net::Groups.
      */
-    explicit Manager(std::array<GroupPtr, kGroupCount>&& groups)
+    explicit Manager(std::array<GroupPtr, kGroupCount>&& groups) noexcept
         : groups_(std::move(groups)) { }
 
     /*!

--- a/thrill/net/tcp/socket.hpp
+++ b/thrill/net/tcp/socket.hpp
@@ -72,7 +72,7 @@ public:
     //! non-copyable: delete assignment operator
     Socket& operator = (const Socket&) = delete;
     //! move-constructor: move file descriptor
-    Socket(Socket&& s) : fd_(s.fd_) { s.fd_ = -1; }
+    Socket(Socket&& s) noexcept : fd_(s.fd_) { s.fd_ = -1; }
     //! move-assignment operator: move file descriptor
     Socket& operator = (Socket&& s) {
         if (this == &s) return *this;


### PR DESCRIPTION
- Sprinkle a ton of things with `noexcept` fairy dust to make standard containers magically faster (see also #80)
- Fix forgotten uses of `std::move` and `std::forward`