### PR TITLE
Split strings with callback instead of temporary objects

### DIFF
--- a/benchmarks/word_count/word_count_bench.cpp
+++ b/benchmarks/word_count/word_count_bench.cpp
@@ -40,17 +40,12 @@ auto WordCount(const DIA<std::string, InStack>& input) {
             [](const std::string& line, auto emit) -> void {
                 /* map lambda: emit each word */
                 auto last = line.begin();
-                for (auto it = line.begin(); it != line.end(); it++) {
-                    if (*it == ' ') {
-                        if (it > last) {
-                            emit(CreateWCPair(last, it - last));
-                        }
-                        last = it + 1;
-                    }
-                }
-                if (line.end() > last) {
-                    emit(CreateWCPair(last, line.end() - last));
-                }
+                thrill::common::SplitCallback(
+                    line, ' ', [&](const auto begin, const auto end) {
+                        if (end > last)
+                            emit(CreateWCPair(begin, end - begin));
+                        last = end + 1;
+                    });
             }).ReducePair(
             [](const size_t& a, const size_t& b) {
                 return a + b;

--- a/examples/word_count.hpp
+++ b/examples/word_count.hpp
@@ -8,25 +8,7 @@
  * All rights reserved. Published under the BSD-2 license in the LICENSE file.
  ******************************************************************************/
 
-#include <thrill/api/generate_from_file.hpp>
-#include <thrill/api/read_lines.hpp>
-#include <thrill/api/reduce.hpp>
-#include <thrill/api/size.hpp>
-#include <thrill/api/write_lines_many.hpp>
-#include <thrill/common/string.hpp>
-#include <thrill/api/generate.hpp>
-#include <thrill/api/groupby_index.hpp>
-#include <thrill/api/read_lines.hpp>
-#include <thrill/api/reduce.hpp>
-#include <thrill/api/reduce_to_index.hpp>
-#include <thrill/api/size.hpp>
-#include <thrill/api/sort.hpp>
-#include <thrill/api/sum.hpp>
-#include <thrill/api/write_lines.hpp>
-#include <thrill/api/zip.hpp>
-#include <thrill/common/cmdline_parser.hpp>
-#include <thrill/common/logger.hpp>
-#include <thrill/common/stats_timer.hpp>
+#include <thrill/thrill.hpp>
 
 #include <algorithm>
 #include <random>
@@ -51,10 +33,9 @@ auto WordCount(const DIA<std::string, InStack> &input) {
     auto word_pairs = input.template FlatMap<WordCountPair>(
             [](const std::string &line, auto emit) -> void {
                 /* map lambda: emit each word */
-                for (const std::string &word : common::Split(line, ' ')) {
-                    if (word.size() != 0)
-                        emit(WordCountPair(word, 1));
-                }
+                thrill::common::SplitCallback(
+                    line, ' ', [&](const auto begin, const auto end)
+                    { emit(WordCountPair(std::string(begin, end), 1)); });
             });
 
     return word_pairs.ReduceBy(

--- a/thrill/common/string.hpp
+++ b/thrill/common/string.hpp
@@ -203,6 +203,50 @@ std::vector<std::string> Split(
 }
 
 /*!
+ * Split the given string at each separator character into distinct substrings,
+ * and call the given callback for each substring, represented by two iterators
+ * begin and end. Multiple consecutive separators are considered individually
+ * and will result in empty split substrings.
+ *
+ * \param str       string to split
+ * \param sep       separator character
+ * \param callback  callback taking begin and end iterator of substring
+ * \param limit     maximum number of parts returned
+ */
+template <typename F>
+static inline
+void SplitCallback(
+    const std::string& str, char sep, F&& callback,
+    std::string::size_type limit = std::string::npos) {
+
+    if (limit == 0)
+    {
+        callback(str.begin(), str.end());
+        return;
+    }
+
+    std::string::size_type count = 0;
+    auto it = str.begin(), last = it;
+
+    for (; it != str.end(); ++it)
+    {
+        if (*it == sep)
+        {
+            if (count == limit)
+            {
+                callback(last, str.end());
+                return;
+            }
+            callback(last, it);
+            ++count;
+            last = it + 1;
+        }
+    }
+    callback(last, it);
+}
+
+
+/*!
  * Join a sequence of strings by some glue string between each pair from the
  * sequence. The sequence in given as a range between two iterators.
  *


### PR DESCRIPTION
No idea if you like this but it makes the word count example significantly faster (only takes ~1/3rd of the time now) and the benchmark more concise (I could't measure a change in running time on the mini input data)