### PR TITLE
Fake libc++ version to appease TBB

### DIFF
--- a/thrill/common/concurrent_bounded_queue.hpp
+++ b/thrill/common/concurrent_bounded_queue.hpp
@@ -14,7 +14,19 @@
 
 #if THRILL_HAVE_INTELTBB
 
+#if __clang__ && !defined(_LIBCPP_VERSION)
+// tbb feature detection is broken for clang + libstdc++
+#define _LIBCPP_VERSION 4000
+#define FAKE_LIBCPP_VERSION
+#endif
+
 #include <tbb/concurrent_queue.h>
+
+#if defined(FAKE_LIBCPP_VERSION)
+// undo libc++ version faking
+#undef _LIBCPP_VERSION
+#undef FAKE_LIBCPP_VERSION
+#endif
 
 #endif // THRILL_HAVE_INTELTBB
 

--- a/thrill/common/concurrent_queue.hpp
+++ b/thrill/common/concurrent_queue.hpp
@@ -14,7 +14,19 @@
 
 #if THRILL_HAVE_INTELTBB
 
+#if __clang__ && !defined(_LIBCPP_VERSION)
+// tbb feature detection is broken for clang + libstdc++
+#define _LIBCPP_VERSION 4000
+#define FAKE_LIBCPP_VERSION
+#endif
+
 #include <tbb/concurrent_queue.h>
+
+#if defined(FAKE_LIBCPP_VERSION)
+// undo libc++ version faking
+#undef _LIBCPP_VERSION
+#undef FAKE_LIBCPP_VERSION
+#endif
 
 #endif // THRILL_HAVE_INTELTBB
 


### PR DESCRIPTION
TBB's feature detection is broken - when using clang, it doesn't consider libstdc++ (the default on many linux distributions), only libc++. Work around this by defining `_LIBCPP_VERSION`.