### PR TITLE
improve join node mem usage by disposing location detection asap

### DIFF
--- a/thrill/api/inner_join.hpp
+++ b/thrill/api/inner_join.hpp
@@ -163,6 +163,7 @@ public:
         if (UseLocationDetection) {
             std::unordered_map<size_t, size_t> target_processors;
             size_t max_hash = location_detection_.Flush(target_processors);
+            location_detection_.Dispose();
 
             auto file1reader = pre_file1_.GetConsumeReader();
             while (file1reader.HasNext()) {

--- a/thrill/core/location_detection.hpp
+++ b/thrill/core/location_detection.hpp
@@ -353,6 +353,11 @@ public:
         return max_hash;
     }
 
+    void Dispose() {
+        table_.Dispose();
+        std::vector<HashCount>().swap(hash_occ_);
+    }
+
     //! Target vector for vector emitter
     std::vector<HashCount> hash_occ_;
     //! Emitter to vector


### PR DESCRIPTION
Previously the location detection - including it's super memory greedy hash table - would persist until end of object lifetime. This would cause problems in the PushData Phase as more memory than available was used there. I don't know if the join memory usage calculations are completely right now but in any case they are more right then before... 