### PR TITLE
Add support for ENV vars in disk config files

### DIFF
--- a/thrill/io/config_file.cpp
+++ b/thrill/io/config_file.cpp
@@ -484,7 +484,7 @@ std::string DiskConfig::fileio_string() const {
     return oss.str();
 }
 
-std::string DiskConfig::expand_path(std::string path) {
+std::string DiskConfig::expand_path(std::string path) const {
     std::regex var_matcher("\\$([A-Z]+(_[A-Z]+)*)");
     std::smatch match;
 

--- a/thrill/io/config_file.cpp
+++ b/thrill/io/config_file.cpp
@@ -495,6 +495,7 @@ std::string DiskConfig::expand_path(std::string path) const {
         ss << std::getenv(match[1].str().c_str());
         path = match.suffix().str();
     }
+    ss << path;
 
     return ss.str();
 }

--- a/thrill/io/config_file.hpp
+++ b/thrill/io/config_file.hpp
@@ -70,6 +70,9 @@ public:
     //! return formatted fileio name and optional configuration parameters
     std::string fileio_string() const;
 
+    //! expand environmental variables in path
+    std::string expand_path(std::string) const;
+
 public:
     //! \name Optional Disk / File I/O Implementation Parameters
     //! \{


### PR DESCRIPTION
This adds support for environment variables in the paths of disk configs. Needed that for experiments on bwUniCluster and couldn't find any other good way to implement it. 