### PR TITLE
Page_Rank_Run example problem solved

### DIFF
--- a/examples/page_rank/page_rank_run.cpp
+++ b/examples/page_rank/page_rank_run.cpp
@@ -97,7 +97,7 @@ static void RunPageRankEdgePerLine(
     if (output_path.size()) {
         ranks.ZipWithIndex(
             // generate index numbers: 0...num_pages-1
-            [](const PageId& p, const Rank& r) {
+            [](const Rank& r, const PageId& p) {
                 return common::str_sprintf("%zu: %g", p, r);
             })
         .WriteLines(output_path);


### PR DESCRIPTION
Working with page_rank example I found an error. The results where wrong and the pageID did not appear as it should. With this small change the problem is solved and, now, the results are as expected:

PageID: Rank