### PR TITLE
Int arithmetics for indexes

### DIFF
--- a/thrill/api/group_to_index.hpp
+++ b/thrill/api/group_to_index.hpp
@@ -96,7 +96,8 @@ public:
     void PreOp(const ValueIn& v) {
         const Key k = key_extractor_(v);
         assert(k < result_size_);
-        const size_t recipient = k * emitter_.size() / result_size_;
+        const size_t recipient = common::CalculatePartition(
+            result_size_, context_.num_workers(), k);
         assert(recipient < emitter_.size());
         emitter_[recipient].Put(v);
     }
@@ -141,6 +142,8 @@ public:
                     puller, key_extractor_);
 
                 while (user_iterator.HasNextForReal()) {
+                    assert(user_iterator.GetNextKey() >= curr_index);
+
                     if (user_iterator.GetNextKey() != curr_index) {
                         // push neutral element as result to callback functions
                         this->PushItem(neutral_element_);
@@ -185,6 +188,8 @@ private:
                 ValueIn, KeyExtractor, ValueComparator>(r, key_extractor_);
             size_t curr_index = key_range_.begin;
             while (user_iterator.HasNextForReal()) {
+                assert(user_iterator.GetNextKey() >= curr_index);
+
                 if (user_iterator.GetNextKey() != curr_index) {
                     // push neutral element as result to callback functions
                     this->PushItem(neutral_element_);

--- a/thrill/common/math.hpp
+++ b/thrill/common/math.hpp
@@ -67,7 +67,14 @@ public:
     //! calculate a partition range [begin,end) by taking the current Range
     //! splitting it into p parts and taking the i-th one.
     Range Partition(size_t index, size_t parts) const {
-        return Range(index * size() / parts, (index + 1) * size() / parts);
+        assert(index < parts);
+        return Range(CalculateBeginOfPart(index, parts),
+            CalculateBeginOfPart(index + 1, parts));
+    }
+
+    size_t CalculateBeginOfPart(size_t index, size_t parts) const {
+        assert(index <= parts);
+        return (index * size() + parts - 1) / parts;
     }
 
     //! ostream-able
@@ -80,13 +87,14 @@ public:
 //! the [local_begin,local_end) index range assigned to the PE i.
 static inline Range CalculateLocalRange(
     size_t global_size, size_t p, size_t i) {
+    return Range(0, global_size).Partition(i, p);
+}
 
-    double per_pe = static_cast<double>(global_size) / static_cast<double>(p);
-    return Range(
-        static_cast<size_t>(std::ceil(static_cast<double>(i) * per_pe)),
-        std::min(static_cast<size_t>(
-                     std::ceil(static_cast<double>(i + 1) * per_pe)),
-                 global_size));
+static inline size_t CalculatePartition(size_t global_size, size_t p, size_t k) {
+    size_t partition = k * p / global_size;
+    assert(k >= CalculateLocalRange(global_size, p, partition).begin);
+    assert(k < CalculateLocalRange(global_size, p, partition).end);
+    return partition;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Fix #163 

This PR removes the `double` based index range partitioning in favor of a equivalent (minus the rounding errors) integer arithmetics based implementation. It also adds some asserts to make sure `GroupToIndex` does not go into endless loops. However, it does not unify the implementations. `ReduceToIndex` and `ReduceFunctional` still contains a different implementation - but it does the same thing.