### PR TITLE
Fix SampleNode

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ thrill_build_test_group(common/tests
   common/qsort_test.cpp
   common/radix_sort_test.cpp
   common/reservoir_sampling_test.cpp
+  common/sampling_test.cpp
   common/splay_tree_test.cpp
   common/stats_counter_test.cpp
   common/stats_timer_test.cpp

--- a/tests/common/sampling_test.cpp
+++ b/tests/common/sampling_test.cpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * tests/common/sampling_test.cpp
+ *
+ * Part of Project Thrill - http://project-thrill.org
+ *
+ * Copyright (C) 2017 Timo Bingmann <tb@panthema.net>
+ * Copyright (C) 2017 Lorenz Hübschle-Schneider <lorenz@4z2.de>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#include <thrill/common/sampling.hpp>
+
+#include <thrill/common/aggregate.hpp>
+#include <thrill/common/logger.hpp>
+#include <tlx/die.hpp>
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <numeric>
+#include <vector>
+
+using namespace thrill;
+
+TEST(Sampling, Simple) {
+
+    // item range inserted
+    static const size_t range = 100000;
+    // number of rounds for histogram
+    static const size_t rounds = 10000;
+    // store reservoir size
+    size_t s_size = 0;
+
+    std::mt19937 rng(std::random_device { } ());
+    std::vector<size_t> histogram(range);
+
+    std::vector<size_t> input(range);
+    // fill with values [0..range)
+    std::iota(input.begin(), input.end(), 0);
+
+    for (size_t r = 0; r < rounds; ++r)
+    {
+        std::vector<size_t> samples;
+        common::Sampling<> s(rng);
+        s(input.begin(), input.end(), 1000, samples);
+
+        for (const auto& x : samples)
+            histogram[x]++;
+
+        s_size = samples.size();
+    }
+
+    double target =
+        static_cast<double>(s_size * rounds) / static_cast<double>(range);
+
+    common::Aggregate<double> aggr;
+
+    for (size_t i = 0; i < histogram.size(); ++i) {
+        aggr.Add((histogram[i] - target) / target);
+    }
+
+    sLOG1 << "target" << target
+          << "mean" << aggr.Mean() << "stdev" << aggr.StDev()
+          << "min" << aggr.Min() << "max" << aggr.Max();
+
+    ASSERT_LT(aggr.Mean(), 0.1);
+    ASSERT_LT(aggr.StDev(), 1.0);
+
+    // std::ofstream of("data.txt");
+    // for (size_t i = 0; i < histogram.size(); ++i) {
+    //     // LOG1 << "histogram[" << i << "] = " << histogram[i];
+    //     of << i << '\t' << histogram[i] << '\n';
+    // }
+}
+
+/******************************************************************************/

--- a/thrill/api/sample.hpp
+++ b/thrill/api/sample.hpp
@@ -16,6 +16,7 @@
 #include <thrill/api/dop_node.hpp>
 #include <thrill/common/hypergeometric_distribution.hpp>
 #include <thrill/common/logger.hpp>
+#include <thrill/common/sampling.hpp>
 #include <thrill/common/reservoir_sampling.hpp>
 
 #include <tlx/math.hpp>
@@ -169,12 +170,9 @@ public:
             sLOG << "Drawing" << local_samples_ << "samples locally from"
                  << samples_.size() << "pre-samples";
             std::vector<ValueType> subsample;
-            common::ReservoirSamplingFast<ValueType, decltype(rng_)> subsampler(
-                local_samples_, subsample, rng_);
-            for (const ValueType& v : samples_) {
-                subsampler.add(v);
-            }
-            // cast the const'ness away, subsampler is dead afterwards
+            common::Sampling<> subsampler(rng_);
+            subsampler(samples_.begin(), samples_.end(),
+                       local_samples_, subsample);
             samples_.swap(subsample);
             LOGC(samples_.size() != local_samples_)
                 << "ERROR: SAMPLE SIZE IS WRONG";

--- a/thrill/api/sample.hpp
+++ b/thrill/api/sample.hpp
@@ -124,7 +124,8 @@ public:
     }
 
     void PushData(bool consume) final {
-        local_timer_.Start();
+        // don't start global timer in pushdata!
+        common::StatsTimerStart push_timer;
 
         sLOGC(local_samples_ > samples_.size())
             << "WTF ERROR CAN'T DRAW" << local_samples_ << "FROM"
@@ -143,7 +144,8 @@ public:
             LOGC(samples_.size() != local_samples_)
                 << "ERROR: SAMPLE SIZE IS WRONG";
         }
-        local_timer_.Stop(); // don't measure PushItem
+        push_timer.Stop(); // don't measure PushItem
+        local_timer_ += push_timer;
 
         for (const ValueType& v : samples_) {
             this->PushItem(v);

--- a/thrill/api/sample.hpp
+++ b/thrill/api/sample.hpp
@@ -14,7 +14,11 @@
 
 #include <thrill/api/dia.hpp>
 #include <thrill/api/dop_node.hpp>
+#include <thrill/common/hypergeometric_distribution.hpp>
 #include <thrill/common/logger.hpp>
+#include <thrill/common/reservoir_sampling.hpp>
+
+#include <tlx/math.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -37,95 +41,175 @@ public:
     template <typename ParentDIA>
     SampleNode(const ParentDIA& parent, size_t sample_size)
         : Super(parent.ctx(), "Sample", { parent.id() }, { parent.node() }),
-          sample_size_(sample_size)
+          sample_size_(sample_size), hyp_(42 /* dummy seed */),
+          parent_stack_empty_(ParentDIA::stack_empty)
     {
-        samples_.reserve(sample_size);
-
-        // Hook PreOp(s)
-        auto pre_op_fn = [this](const ValueType& input) {
-                             PreOp(input);
-                         };
-
-        auto lop_chain = parent.stack().push(pre_op_fn).fold();
+        auto save_fn = [this](const ValueType& input) {
+            writer_.Put(input);
+        };
+        auto lop_chain = parent.stack().push(save_fn).fold();
         parent.node()->AddChild(this, lop_chain);
     }
 
-    DIAMemUse PreOpMemUse() final {
-        return sample_size_ * sizeof(ValueType);
+    bool OnPreOpFile(const data::File& file, size_t /* parent_index */) final {
+        if (!parent_stack_empty_) {
+            LOGC(common::g_debug_push_file)
+                << "Sample rejected File from parent "
+                << "due to non-empty function stack.";
+            return false;
+        }
+        assert(file_.num_items() == 0);
+        file_ = file.Copy();
+        return true;
     }
 
-    void PreOp(const ValueType& input) {
-        if (samples_.size() < sample_size_) {
-            samples_.emplace_back(input);
-        }
-        else {
-            samples_[rng_() % samples_.size()] = input;
-        }
+    void StopPreOp(size_t /* id */) final {
+        // Push local elements to children
+        writer_.Close();
     }
 
     void Execute() final {
+        LOG << "SampleNode::Execute() processing";
+        const size_t local_size = file_.num_items();
+        sLOG << "local_size" << local_size;
 
-        size_t local_size = samples_.size();
+        const size_t my_rank = context_.my_rank();
+        const size_t num_workers = context_.num_workers();
 
-        size_t local_rank = local_size;
-        size_t global_size = context_.net.ExPrefixSumTotal(local_rank);
+        if (num_workers == 1) {
+            sample_size_ = std::min(sample_size_, local_size);
+            local_samples_ = sample_size_;
+            sLOG << "SampleNode::Execute (alone)"
+                 << local_samples_ << "of" << sample_size_ << "samples";
 
-        // not enough items to discard some, done.
-        if (global_size < sample_size_) return;
-
-        // synchronize global random generator
-        size_t seed = context_.my_rank() == 0 ? rng_() : 0;
-        seed = context_.net.Broadcast(seed);
-        rng_.seed(static_cast<unsigned>(seed));
-
-        // globally select random samples among samples_
-        typename std::vector<ValueType>::iterator it = samples_.begin();
-
-        for (size_t i = 0; i < sample_size_; ++i) {
-            size_t r = rng_() % sample_size_;
-            if (r < local_rank || r >= local_rank + local_size) continue;
-
-            // swap selected item to front.
-            using std::swap;
-            if (it < samples_.end()) {
-                swap(*it, samples_[r - local_rank]);
-            }
-            else {
-                it = samples_.insert(it, samples_[r - local_rank]);
-            }
-            ++it;
+            return;
         }
 
-        samples_.erase(it, samples_.end());
+        std::vector<size_t> input_sizes(num_workers);
+        input_sizes[my_rank] = local_size;
+        // there's no group::all_gather... do it totally naively
+        for (size_t i = 0; i < num_workers; ++i) {
+            input_sizes[i] = context_.net.Broadcast(input_sizes[i], i);
+        }
+
+        // Determine and broadcast seed
+        size_t seed = 0;
+        if (context_.my_rank() == 0) {
+            seed = std::random_device{}();
+        }
+        seed = context_.net.Broadcast(seed, 0);
+        // Seed hypergeometric distribution with the same value on each PE
+        hyp_.seed(seed);
+
+        // Build size tree
+        const size_t num_leaves = tlx::round_up_to_power_of_two(num_workers);
+        std::vector<size_t> tree(2 * num_leaves - 1);
+        for (size_t i = 0; i < num_workers; ++i) {
+            tree[num_leaves + i - 1] = input_sizes[i];
+        }
+        const size_t height = tlx::integer_log2_ceil(num_workers);
+        for (size_t i = 0; i < height; ++i) {
+            const size_t min = num_leaves / (1ULL << (i + 1)) - 1;
+            for (size_t j = min; j <= 2 * min; ++j) {
+                tree[j] = tree[2 * j + 1] + tree[2 * j + 2];
+            }
+        }
+
+        LOG << "Input sizes: " << input_sizes;
+        LOG << "Tree: " << tree;
+
+        if (tree[0] < sample_size_) {
+            // more samples requested than there are elements
+            sample_size_ = tree[0];
+            local_samples_ = local_size;
+            sLOG << "SampleNode::Execute (underfull)"
+                 << local_samples_ << "of" << sample_size_ << "samples";
+            return;
+        }
+
+        size_t total = sample_size_, base = 1;
+        for (size_t i = 0; i < height; ++i) {
+            // get hypergeometric deviate. the sequence of calls is exactly the
+            // same up to two workers' LCA in the binary tree above all workers,
+            // i.e. until they no longer depend on each other
+            hyp_.seed(seed + base);
+            size_t left = hyp_(tree[base], tree[base + 1], total);
+            // descend into correct branch
+            const bool go_right = my_rank & (1ULL << (height - i - 1));
+
+            sLOG << "Level" << i << "distributing" << total << "samples,"
+                 << "base index:" << base
+                 << "left size:" << tree[base] << "right:" << tree[base + 1]
+                 << "result for left:" << left
+                 << "going" << (go_right ? "right" : "left");
+
+            if (go_right) {
+                base = 2 * base + 3;
+                total = total - left;
+            } else {
+                base = 2 * base + 1;
+                total = left;
+            }
+        }
+
+        local_samples_ = total;
+
+        if (local_samples_ > local_size) {
+            sLOG1 << "Sample error: need" << local_samples_ << ">"
+                  << local_size << "(=available) elements from this worker";
+        }
 
         sLOG << "SampleNode::Execute"
-             << "global_size" << global_size
-             << "local_rank" << local_rank
-             << "AllReduce" << context_.net.AllReduce(samples_.size());
-
-        assert(sample_size_ == context_.net.AllReduce(samples_.size()));
+             << local_samples_ << "of" << sample_size_ << "samples";
     }
 
     void PushData(bool consume) final {
-        for (const ValueType& v : samples_) {
+        samples_.clear();
+
+        const size_t local_size = file_.num_items();
+        if (local_samples_ == local_size) {
+            LOG << "Sample: returning all local items";
+            auto reader = file_.GetReader(consume);
+            while (reader.HasNext()) {
+                this->PushItem(reader.template Next<ValueType>());
+            }
+            return;
+        }
+
+        sLOG << "Drawing" << local_samples_ << "locally from" << local_size;
+        common::ReservoirSamplingFast<ValueType> sampler(
+            local_samples_, samples_, rng_);
+
+        auto reader = file_.GetReader(consume);
+        while (reader.HasNext()) {
+            sampler.add(reader.template Next<ValueType>());
+        }
+
+        for (const ValueType& v : sampler.samples()) {
             this->PushItem(v);
         }
-        if (consume)
-            std::vector<ValueType>().swap(samples_);
     }
 
     void Dispose() final {
-        std::vector<ValueType>().swap(samples_);
+        file_.Clear();
     }
 
 private:
-    size_t sample_size_;
-
+    //! Local data file
+    data::File file_ { context_.GetFile(this) };
+    //! Data writer to local file (only active in PreOp).
+    data::File::Writer writer_ { file_.GetWriter() };
+    //! number of samples to draw globally
+    size_t sample_size_, local_samples_;
     //! local samples
     std::vector<ValueType> samples_;
-
+    //! Hypergeometric distribution to calculate local sample sizes
+    common::hypergeometric hyp_;
     //! Random generator for eviction
     std::default_random_engine rng_ { std::random_device { } () };
+    //! Whether the parent stack is empty
+    const bool parent_stack_empty_;
+
 };
 
 template <typename ValueType, typename Stack>

--- a/thrill/common/hypergeometric_distribution.hpp
+++ b/thrill/common/hypergeometric_distribution.hpp
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * thrill/common/hypergeometric_distribution.hpp
+ *
+ * A hypergeomitric distribution random generator adapted from NumPy.
+ *
+ * The implementation of loggam(), rk_hypergeometric(), rk_hypergeometric_hyp(),
+ * and rk_hypergeometric_hrua() were adapted from NumPy's
+ * numpy/random/mtrand/distributions.c which has this license:
+ *
+ * Copyright 2005 Robert Kern (robert.kern@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * The implementations of rk_hypergeometric_hyp(), rk_hypergeometric_hrua(),
+ * and rk_triangular() were adapted from Ivan Frohne's rv.py which has this
+ * license:
+ *
+ *            Copyright 1998 by Ivan Frohne; Wasilla, Alaska, U.S.A.
+ *                            All Rights Reserved
+ *
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation for any purpose, free of charge, is granted subject to the
+ * following conditions:
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the software.
+ *
+ *   THE SOFTWARE AND DOCUMENTATION IS PROVIDED WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO MERCHANTABILITY, FITNESS
+ *   FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHOR
+ *   OR COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM OR DAMAGES IN A CONTRACT
+ *   ACTION, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ *   SOFTWARE OR ITS DOCUMENTATION.
+ *
+ *
+ * Part of Project Thrill - http://project-thrill.org
+ *
+ * Copyright (C) 2017 Lorenz Hübschle-Schneider <lorenz@4z2.de>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+#ifndef THRILL_COMMON_HYPERGEOMETRIC_DISTRIBUTION_HEADER
+#define THRILL_COMMON_HYPERGEOMETRIC_DISTRIBUTION_HEADER
+
+#include <thrill/common/logger.hpp>
+
+#include <cmath>
+#include <random>
+
+namespace thrill {
+namespace common {
+
+template <typename int_t = int64_t, typename fp_t = double>
+class hypergeometric_distribution
+{
+public:
+    using result_type = int_t;
+    using real_type = fp_t;
+
+    hypergeometric_distribution(size_t seed = 0)
+        : rng(seed != 0 ? seed : std::random_device{}()) {}
+
+    int_t operator()(int_t good, int_t bad, int_t sample) {
+        if (sample < 1) {
+            sLOG1 << "hypergeometric distribution error: sample < 1:" << sample;
+            return static_cast<int_t>(-1);
+        }
+        if (good + bad < sample) {
+            sLOG1 << "hypergeometric distribution error: good + bad < sample:"
+                  << "good:" << good << "bad:" << bad << "sample:" << sample;
+            return static_cast<int_t>(-1);
+        }
+        return rk_hypergeometric(good, bad, sample);
+    }
+
+    void seed(size_t seed_val) {
+        rng.seed(seed_val);
+    }
+
+private:
+    /*
+     * log-gamma function to support some of these distributions. The
+     * algorithm comes from SPECFUN by Shanjie Zhang and Jianming Jin and their
+     * book "Computation of Special Functions", 1996, John Wiley & Sons, Inc.
+     */
+    fp_t loggam(fp_t x) const {
+        fp_t x0, x2, xp, gl, gl0;
+        int_t k, n;
+
+        static fp_t a[10] = {8.333333333333333e-02,-2.777777777777778e-03,
+                             7.936507936507937e-04,-5.952380952380952e-04,
+                             8.417508417508418e-04,-1.917526917526918e-03,
+                             6.410256410256410e-03,-2.955065359477124e-02,
+                             1.796443723688307e-01,-1.39243221690590e+00};
+        x0 = x;
+        n = 0;
+        if ((x == 1.0) || (x == 2.0))
+        {
+            return 0.0;
+        }
+        else if (x <= 7.0)
+        {
+            n = static_cast<int_t>(7 - x);
+            x0 = x + n;
+        }
+        x2 = 1.0/(x0*x0);
+        xp = 2*M_PI;
+        gl0 = a[9];
+        for (k=8; k>=0; k--)
+        {
+            gl0 *= x2;
+            gl0 += a[k];
+        }
+        gl = gl0/x0 + 0.5*std::log(xp) + (x0-0.5)*std::log(x0) - x0;
+        if (x <= 7.0)
+        {
+            for (k=1; k<=n; k++)
+            {
+                gl -= std::log(x0-1.0);
+                x0 -= 1.0;
+            }
+        }
+        return gl;
+    }
+
+    /* D1 = 2*sqrt(2/e) */
+    /* D2 = 3 - 2*sqrt(3/e) */
+    static constexpr fp_t D1 = 1.7155277699214135;
+    static constexpr fp_t D2 = 0.8989161620588988;
+
+    int_t rk_hypergeometric_hyp(int_t good, int_t bad, int_t sample) {
+        int_t d1, K, Z;
+        fp_t d2, U, Y;
+
+        d1 = bad + good - sample;
+        d2 = static_cast<fp_t>(std::min(bad, good));
+
+        Y = d2;
+        K = sample;
+        while (Y > 0.0) {
+            U = dist(rng); // rk_double(state);
+            Y -= static_cast<int_t>(floor(U + Y / (d1 + K)));
+            K--;
+            if (K == 0) break;
+        }
+        Z = static_cast<int_t>(d2 - Y);
+        if (good > bad) Z = sample - Z;
+        return Z;
+    }
+
+    int_t rk_hypergeometric_hrua(int_t good, int_t bad, int_t sample) {
+        int_t mingoodbad, maxgoodbad, popsize, m, d9;
+        fp_t d4, d5, d6, d7, d8, d10, d11;
+        int_t Z;
+        fp_t T, W, X, Y;
+
+        mingoodbad = std::min(good, bad);
+        popsize = good + bad;
+        maxgoodbad = std::max(good, bad);
+        m = std::min(sample, popsize - sample);
+        d4 = static_cast<fp_t>(mingoodbad) / popsize;
+        d5 = 1.0 - d4;
+        d6 = m * d4 + 0.5;
+        d7 = sqrt(static_cast<fp_t>(popsize - m) * sample * d4 * d5 /
+                  (popsize - 1) + 0.5);
+        d8 = D1 * d7 + D2;
+        d9 = static_cast<int_t>(floor(static_cast<fp_t>(m + 1) *
+                                      (mingoodbad + 1) / (popsize + 2)));
+        d10 =
+            (loggam(d9 + 1) + loggam(mingoodbad - d9 + 1) + loggam(m - d9 + 1) +
+             loggam(maxgoodbad - m + d9 + 1));
+        d11 = std::min(std::min(m, mingoodbad) + 1.0, floor(d6 + 16 * d7));
+        /* 16 for 16-decimal-digit precision in D1 and D2 */
+
+        while (1) {
+            X = dist(rng); // rk_double(state);
+            Y = dist(rng); // rk_double(state);
+            W = d6 + d8 * (Y - 0.5) / X;
+
+            /* fast rejection: */
+            if ((W < 0.0) || (W >= d11)) continue;
+
+            Z = static_cast<int_t>(floor(W));
+            T = d10 - (loggam(Z + 1) + loggam(mingoodbad - Z + 1) +
+                       loggam(m - Z + 1) + loggam(maxgoodbad - m + Z + 1));
+
+            /* fast acceptance: */
+            if ((X * (4.0 - X) - 3.0) <= T) break;
+
+            /* fast rejection: */
+            if (X * (X - T) >= 1) continue;
+
+            if (2.0 * std::log(X) <= T) break; /* acceptance */
+        }
+
+        /* this is a correction to HRUA* by Ivan Frohne in rv.py */
+        if (good > bad) Z = m - Z;
+
+        /* another fix from rv.py to allow sample to exceed popsize/2 */
+        if (m < sample) Z = good - Z;
+
+        return Z;
+    }
+
+    int_t rk_hypergeometric(int_t good, int_t bad, int_t sample) {
+        if (sample > 10) {
+            return rk_hypergeometric_hrua(good, bad, sample);
+        } else {
+            return rk_hypergeometric_hyp(good, bad, sample);
+        }
+    }
+
+    // Data members:
+    std::mt19937 rng; // random number generator
+    std::uniform_real_distribution<fp_t> dist; // [0.0...1.0) distribution
+};
+
+using hypergeometric = hypergeometric_distribution<>;
+
+
+} // namespace common
+} // namespace thrill
+
+#endif // !THRILL_COMMON_HYPERGEOMETRIC_DISTRIBUTION_HEADER
+
+/******************************************************************************/

--- a/thrill/common/hypergeometric_distribution.hpp
+++ b/thrill/common/hypergeometric_distribution.hpp
@@ -65,6 +65,7 @@
 
 #include <cmath>
 #include <random>
+#include <type_traits>
 
 namespace thrill {
 namespace common {
@@ -104,7 +105,7 @@ private:
      */
     fp_t loggam(fp_t x) const {
         fp_t x0, x2, xp, gl, gl0;
-        int_t k, n;
+        std::make_signed_t<int_t> k, n;
 
         static fp_t a[10] = {8.333333333333333e-02,-2.777777777777778e-03,
                              7.936507936507937e-04,-5.952380952380952e-04,

--- a/thrill/common/reservoir_sampling.hpp
+++ b/thrill/common/reservoir_sampling.hpp
@@ -104,12 +104,15 @@ public:
             else {
                 // use Vitter's algorithm for small count_
                 size_t x = uniform(rng_) * count_;
-                if (x < size_)
+                if (x < size_) {
                     samples_[x] = item;
+                    // need to update W_ continuously...
+                    update_W();
+                }
 
                 // when count_ reaches 4 * size_ switch to gap algorithm
                 if (count_ == 4 * size_)
-                    calc_next_gap();
+                    update_gap();
             }
         }
         else if (gap_ == 0) {
@@ -151,10 +154,18 @@ private:
     //! uniform [0.0, 1.0) distribution
     std::uniform_real_distribution<double> uniform;
 
-    //! draw gap size from geometric distribution with p = size_ / count_
-    void calc_next_gap() {
+    void update_W() {
         W_ *= std::exp(std::log(uniform(rng_)) / size_);
+    }
+
+    void update_gap() {
         gap_ = std::log(uniform(rng_)) / std::log(1 - W_);
+    }
+
+    //! update gap and W
+    void calc_next_gap() {
+        update_W();
+        update_gap();
     }
 };
 

--- a/thrill/common/reservoir_sampling.hpp
+++ b/thrill/common/reservoir_sampling.hpp
@@ -68,7 +68,7 @@ private:
     //! number of items seen
     size_t count_ = 0;
     //! reservoir
-    std::vector<Type> samples_;
+    std::vector<Type>& samples_;
     //! source of randomness
     RNG& rng_;
 };

--- a/thrill/common/sampling.hpp
+++ b/thrill/common/sampling.hpp
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * thrill/common/sampling.hpp
+ *
+ * Part of Project Thrill - http://project-thrill.org
+ *
+ * Copyright (C) 2016 Sebastian Lamm <seba.lamm@gmail.com>
+ * Copyright (C) 2017 Lorenz Hübschle-Schneider <lorenz@4z2.de>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#pragma once
+#ifndef THRILL_COMMON_SAMPLING_HEADER
+#define THRILL_COMMON_SAMPLING_HEADER
+
+#include <thrill/common/hypergeometric_distribution.hpp>
+#include <thrill/common/logger.hpp>
+
+#include <tlx/define.hpp>
+#include <tlx/math.hpp>
+
+#include <cmath>
+#include <type_traits>
+#include <vector>
+
+namespace thrill {
+namespace common {
+
+//! Sampling without replacement, implementing Algorithm R from Sanders, Lamm,
+//! Hübschle-Schneider, Schrade, Dachsbacher, ACM TOMS 2017: Efficient Random
+//! Sampling - Parallel, Vectorized, Cache-Efficient, and Online
+template <typename RNG = std::mt19937>
+class Sampling {
+public:
+    static constexpr bool debug = false;
+
+    Sampling(RNG& rng) : rng_(rng), hyp_(rng()) {}
+
+    template <typename Iterator,
+              typename Type = typename std::iterator_traits<Iterator>::value_type>
+    void operator()(Iterator begin, Iterator end, size_t size,
+                    std::vector<Type>& samples) {
+        samples.resize(size);
+        do_sample(begin, end, size, samples.begin());
+    }
+
+    template <typename Iterator, typename OutputIterator>
+    void operator()(Iterator begin, Iterator end, size_t size,
+                    OutputIterator out_begin)
+    {
+        do_sample(begin, end, size, out_begin);
+    }
+
+private:
+    template <typename Iterator, typename OutputIterator>
+    void do_sample(Iterator begin, Iterator end, size_t size,
+                   OutputIterator out_begin)
+    {
+        if (size == 0) return; // degenerate
+
+        const size_t insize = end - begin;
+        if (size == insize) { // degenerate
+            std::copy(begin, end, out_begin);
+        } else if (insize > 64) { // recursive step
+            size_t left_size = insize / 2;
+            size_t left = hyp_(left_size, insize - left_size, size);
+            sLOG << "Splitting input of size" << insize << "into two, left"
+                 << left_size << "elements get" << left << "of"
+                 << size << "samples";
+            do_sample(begin, begin + left_size, left,        out_begin);
+            do_sample(begin + left_size, end,   size - left, out_begin + left);
+        } else if (insize > 32 && size > 8) { // hash base case
+            sLOG << "Base case for size" << insize << "and" << size << "samples";
+            hash_sample(begin, end, size, out_begin);
+        } else { // mini base case
+            sLOG << "Mini case for size" << insize << "and" << size << "samples";
+            std::vector<size_t> sample;
+            sample.reserve(size);
+            std::uniform_int_distribution<size_t> dist(0, insize - 1);
+            size_t remaining = size;
+            while (remaining > 0) {
+                size_t elem = dist(rng_);
+                if (std::find(sample.begin(), sample.end(), elem) == sample.end()) {
+                    sample.push_back(elem);
+                    *(out_begin + size - remaining) = *(begin + elem);
+                    --remaining;
+                }
+            }
+        }
+    }
+
+    template <typename Iterator, typename OutIterator,
+              typename Type = typename std::iterator_traits<Iterator>::value_type>
+    void hash_sample(Iterator begin, Iterator end, size_t size,
+                     OutIterator out_begin)
+    {
+        const size_t insize = end - begin;
+        if (insize <= size) {
+            // degenerate case
+            std::copy(begin, end, out_begin);
+            return;
+        }
+        sLOG << "HashSampling" << size << "of" << insize << "elements";
+
+        std::uniform_int_distribution<size_t> dist(0, insize - 1);
+        const size_t dummy = -1;
+        const size_t population_lg = tlx::integer_log2_floor(insize);
+        const size_t table_lg = 3 + tlx::integer_log2_floor(size);
+        const size_t table_size = 1ULL << table_lg;
+        const size_t address_mask = (table_lg >= population_lg) ? 0 :
+            population_lg - table_lg;
+
+        sLOG << "Table size:" << table_size << "(lg:" << table_lg << " pop_lg:"
+             << population_lg << " mask:" << address_mask << ")";
+
+        if (table_size > hash_table.size()) {
+            sLOG << "Resizing table from" << hash_table.size() << "to"
+                 << table_size;
+            hash_table.resize(table_size, dummy);
+        }
+        indices.reserve(table_size);
+
+        size_t remaining = size;
+        while (remaining > 0) {
+            size_t variate, index;
+            while (true) {
+                // Take sample
+                variate = dist(rng_); //N * randblock[array_index++];
+                index = variate >> address_mask;
+                size_t hash_elem = hash_table[index];
+
+                // Table lookup
+                if (TLX_LIKELY(hash_elem == dummy)) break; // done
+                else if (hash_elem == variate) continue; // already sampled
+                else {
+                increment:
+                    ++index;
+                    index &= (table_size - 1);
+                    hash_elem = hash_table[index];
+                    if (hash_elem == dummy) break; // done
+                    else if (hash_elem == variate) continue; // already sampled
+                    goto increment; // keep incrementing
+                }
+            }
+            // Add sample
+            hash_table[index] = variate;
+            *(out_begin + size - remaining) = *(begin + variate);
+            sLOG << "sample no" << size - remaining << "= elem" << variate;
+            indices.push_back(index);
+            remaining--;
+        }
+
+        // clear table
+        for (size_t index : indices)
+            hash_table[index] = dummy;
+        indices.clear();
+    }
+
+    RNG& rng_;
+    common::hypergeometric hyp_;
+    std::vector<size_t> hash_table, indices;
+};
+
+} // namespace common
+} // namespace thrill
+
+#endif // !THRILL_COMMON_SAMPLING_HEADER
+
+/******************************************************************************/


### PR DESCRIPTION
This one should actually compute a random sample without replacement :)

Maybe it would be nice to have sampling *with* replacement in the future.  This should be possible fairly easily by modifying the PreOp, the assignment scheme distribution (binomial instead of hypergeometric), and the PostOp sampler.