### PR TITLE
SortStable DOp for DIAs

### DIFF
--- a/thrill/api/dia.hpp
+++ b/thrill/api/dia.hpp
@@ -1602,6 +1602,41 @@ public:
               const SortFunction& sort_algorithm) const;
 
     /*!
+     * SortStable is a DOp, which sorts a given DIA stably according to the
+     *  given compare_function.
+     *
+     * \tparam CompareFunction Type of the compare_function.
+     *  Should be (ValueType,ValueType)->bool
+     *
+     * \param compare_function Function, which compares two elements. Returns
+     * true, if first element is smaller than second. False otherwise.
+     *
+     * \ingroup dia_dops
+     */
+    template <typename CompareFunction = std::less<ValueType> >
+    auto SortStable(const CompareFunction& compare_function = CompareFunction()) const;
+
+    /*!
+     * SortStable is a DOp, which sorts a given DIA stably according to the
+     *  given compare_function.
+     *
+     * \tparam CompareFunction Type of the compare_function.
+     *  Should be (ValueType,ValueType)->bool
+     *
+     * \param compare_function Function, which compares two elements. Returns
+     * true, if first element is smaller than second. False otherwise.
+     *
+     * \param sort_algorithm Algorithm class used to stably sort items. Merging
+     * is always done using a tournament tree with compare_function. In order
+     * for the sorting to be stable, this must be a stable sorting algorithm.
+     *
+     * \ingroup dia_dops
+     */
+    template <typename CompareFunction, typename SortFunction>
+    auto SortStable(const CompareFunction& compare_function,
+              const SortFunction& sort_algorithm) const;
+
+    /*!
      * Merge is a DOp, which merges two sorted DIAs to a single sorted DIA.
      * Both input DIAs must be used sorted conforming to the given comparator.
      * The type of the output DIA will be the type of this DIA.

--- a/thrill/api/sort.hpp
+++ b/thrill/api/sort.hpp
@@ -245,7 +245,6 @@ public:
 
                 StartPrefetch(seq, prefetch);
 
-                //FIXME unhardcode "stable"
                 auto puller = MakeMultiwayMergeTree(
                     seq.begin(), seq.end(), compare_function_);
 
@@ -280,7 +279,6 @@ public:
 
             StartPrefetch(seq, prefetch);
 
-            // FIXME unhardcode "stable"
             auto puller = MakeMultiwayMergeTree(
                 seq.begin(), seq.end(), compare_function_);
 

--- a/thrill/api/sort.hpp
+++ b/thrill/api/sort.hpp
@@ -50,7 +50,7 @@ namespace api {
  *
  * \tparam SortAlgorithm Type of the local sort function
  *
- * \tparam TranmissionStreamType Type of the item transmission stream
+ * \tparam Stable Whether or not to use stable sorting mechanisms
  *
  * \ingroup api_layer
  */


### PR DESCRIPTION
I need a stable sorting operation on DIAs for my master's thesis.
However, the `Sort` DOp does not sort the given input sequence stably. I identified three reasons for this:

1. The local sorting of buckets is done using `std::sort` by default, which is not stable.
1. If a local bucket is too large, it is split into multiple files. These are sorted one by one and the sorted sequences are then put together in a multiway merge step. This multiway merging is not stable by default.
1. The assignment of input elements to the corresponding workers (buckets) happens asynchronously. This means that a worker scanning a late part of the input sequence may put an element into its bucket before a worker scanning an early part of the input does. In this case, the respective bucket is no longer in input order and stability is lost.

I implemented a `SortStable` DOp which addresses these issues:
1. By default, it uses `std::stable_sort` for local sorting.
1. The multiway merger uses a loser tree with the `Stable` flag set to `true`. Because the files are in transmitted item order (and thanks to the synchronization in point 3), this already does the trick.
1. Instead of using a `MixStream` to transmit items to their corresponding workers, it uses a `CatStream`. This way, items are put into their buckets with respect to what node they are coming from - lower worker ID means earlier in the bucket.

In order to avoid code duplication, I decided to not create a `SortStableNode`, but instead add a `Stable` template parameter to `SortNode`, depending on which different stream / multiway merge types are picked. I added such a flag to the `MultiwayMergeTree` as well - here, it is passed to the `LoserTree` class. This allowed me to add the `make_stable_multiway_merge_tree` function as an alternative to the classic, non-stable version.

Since the `Stable` flag is defaulted to `false` everywhere, its introduction should have no impact on any existing code. Furthermore, Because everything is evaluated at compile-time, there should be zero overhead for the standard `Sort` DOp.

My additions come with tests and (hopefully) proper doc comments.